### PR TITLE
Add AMIP setup instructions for coarse model inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,177 @@
 site
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ python3 scripts/train_coarse.py --loop.noise_distribution log_uniform --loop.sig
 
 ### Inference
 
-AMIP SST data must be provided as a conditioning input to inference the coarse models. First run `python3 scripts/download_amip_sst.py` to download the data, and then configure `AMIP_MID_MONTH_SST` and `AMIP_MID_MONTH_SST_PROFILE` accordingly to point to the downloaded data in `src/cbottle/config/environment.py`.
+AMIP SST data must be provided as a conditioning input to inference the coarse models. First run `python3 scripts/download_amip_sst.py` to download the data, and then configure `AMIP_MID_MONTH_SST` and `AMIP_MID_MONTH_SST_PROFILE` in `src/cbottle/config/environment.py` to point to the downloaded data.
 
 Once the AMIP SST data is configured, see `scripts/inference_coarse.py`.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ python3 scripts/train_coarse.py --loop.noise_distribution log_uniform --loop.sig
 
 ### Inference
 
-See `scripts/inference_coarse.py`.
+AMIP SST data must be provided as a conditioning input to inference the coarse models. First run `python3 scripts/download_amip_sst.py` to download the data, and then configure `AMIP_MID_MONTH_SST` and `AMIP_MID_MONTH_SST_PROFILE` accordingly to point to the downloaded data in `src/cbottle/config/environment.py`.
+
+Once the AMIP SST data is configured, see `scripts/inference_coarse.py`.
 
 ## Coarse Video Model (cBottle-video)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,18 @@ python3 scripts/train_coarse.py --loop.noise_distribution log_uniform --loop.sig
 
 ### Inference
 
-AMIP SST data must be provided as a conditioning input to inference the coarse models. First run `python3 scripts/download_amip_sst.py` to download the data, and then configure `AMIP_MID_MONTH_SST` and `AMIP_MID_MONTH_SST_PROFILE` in `src/cbottle/config/environment.py` to point to the downloaded data.
+AMIP monthly mean SST data is required as a conditioning input to inference the coarse models. Follow these steps:
+
+1. Download the data:
+   ```bash
+   python3 scripts/download_amip_sst.py
+   ```
+
+2. Configure the environment variables to point to the downloaded data:
+   ```bash
+   export AMIP_MID_MONTH_SST="/path/to/data"
+   export AMIP_MID_MONTH_SST_PROFILE=""
+   ```
 
 Once the AMIP SST data is configured, see `scripts/inference_coarse.py`.
 

--- a/scripts/download_amip_sst.py
+++ b/scripts/download_amip_sst.py
@@ -36,7 +36,7 @@ def download_sst(output_path: str):
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
         ds.to_netcdf(output_path)  # Save to netCDF
-        print(f"Successfully downloaded SST data")
+        print("Successfully downloaded SST data")
 
     except Exception as e:
         print(f"Error downloading SST data: {e}")

--- a/scripts/download_amip_sst.py
+++ b/scripts/download_amip_sst.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import os
+import sys
+import xarray as xr
+from pathlib import Path
+
+AMIP_SST_FILENAME = (
+    "tosbcs_input4MIPs_SSTsAndSeaIce_CMIP_PCMDI-AMIP-1-1-9_gn_187001-202212.nc"
+)
+AMIP_SST_URL = (
+    "https://esgf.ceda.ac.uk/thredds/dodsC/esg_cmip6/input4MIPs/CMIP6Plus/CMIP/"
+    f"PCMDI/PCMDI-AMIP-1-1-9/ocean/mon/tosbcs/gn/v20230512/{AMIP_SST_FILENAME}"
+)
+DEFAULT_CACHE_DIR = os.path.expanduser("~/.cache/cbottle")
+
+
+def download_sst(output_path: str):
+    try:
+        print(f"Downloading SST data to {output_path} ...")
+        ds = xr.open_dataset(AMIP_SST_URL)
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+        ds.to_netcdf(output_path)  # Save to netCDF
+        print(f"Successfully downloaded SST data")
+
+    except Exception as e:
+        print(f"Error downloading SST data: {e}")
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output-path",
+        "-o",
+        type=str,
+        help="Path to save the AMIP SST NetCDF file",
+        default=os.path.join(DEFAULT_CACHE_DIR, AMIP_SST_FILENAME),
+    )
+
+    args = parser.parse_args()
+    download_sst(args.output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cbottle/config/environment.py
+++ b/src/cbottle/config/environment.py
@@ -39,6 +39,7 @@ V6_ICON_ZARR_PROFILE = "pbss"
 RAW_DATA_PROFILE = "pbss"
 SST_MONMEAN_DATA_PROFILE = "pbss"
 LAND_DATA_PROFILE = "pbss"
+AMIP_MID_MONTH_SST_PROFILE = "pbss"
 
 LAND_DATA_URL_10 = os.getenv(
     "LAND_DATA_URL_10", "s3://ICON_cycle3_ngc3028/landfraction/ngc3028_P1D_10.zarr/"

--- a/src/cbottle/config/environment.py
+++ b/src/cbottle/config/environment.py
@@ -35,11 +35,11 @@ RAW_DATA_URL = "s3://ICON_cycle3_ngc3028/ngc3028_PT30M_10.zarr/"
 V6_ICON_ZARR = os.getenv(
     "V6_ICON_ZARR", "s3://asubramaniam-testing/ICON_v6_dataset.zarr/"
 )
-V6_ICON_ZARR_PROFILE = "pbss"
-RAW_DATA_PROFILE = "pbss"
-SST_MONMEAN_DATA_PROFILE = "pbss"
-LAND_DATA_PROFILE = "pbss"
-AMIP_MID_MONTH_SST_PROFILE = "pbss"
+V6_ICON_ZARR_PROFILE = os.getenv("V6_ICON_ZARR_PROFILE", "pbss")
+RAW_DATA_PROFILE = os.getenv("RAW_DATA_PROFILE", "pbss")
+SST_MONMEAN_DATA_PROFILE = os.getenv("SST_MONMEAN_DATA_PROFILE", "pbss")
+LAND_DATA_PROFILE = os.getenv("LAND_DATA_PROFILE", "pbss")
+AMIP_MID_MONTH_SST_PROFILE = os.getenv("AMIP_MID_MONTH_SST_PROFILE", "pbss")
 
 LAND_DATA_URL_10 = os.getenv(
     "LAND_DATA_URL_10", "s3://ICON_cycle3_ngc3028/landfraction/ngc3028_P1D_10.zarr/"

--- a/src/cbottle/config/environment.py
+++ b/src/cbottle/config/environment.py
@@ -35,11 +35,11 @@ RAW_DATA_URL = "s3://ICON_cycle3_ngc3028/ngc3028_PT30M_10.zarr/"
 V6_ICON_ZARR = os.getenv(
     "V6_ICON_ZARR", "s3://asubramaniam-testing/ICON_v6_dataset.zarr/"
 )
-V6_ICON_ZARR_PROFILE = os.getenv("V6_ICON_ZARR_PROFILE", "pbss")
-RAW_DATA_PROFILE = os.getenv("RAW_DATA_PROFILE", "pbss")
-SST_MONMEAN_DATA_PROFILE = os.getenv("SST_MONMEAN_DATA_PROFILE", "pbss")
-LAND_DATA_PROFILE = os.getenv("LAND_DATA_PROFILE", "pbss")
-AMIP_MID_MONTH_SST_PROFILE = os.getenv("AMIP_MID_MONTH_SST_PROFILE", "pbss")
+V6_ICON_ZARR_PROFILE = os.getenv("V6_ICON_ZARR_PROFILE", "")
+RAW_DATA_PROFILE = os.getenv("RAW_DATA_PROFILE", "")
+SST_MONMEAN_DATA_PROFILE = os.getenv("SST_MONMEAN_DATA_PROFILE", "")
+LAND_DATA_PROFILE = os.getenv("LAND_DATA_PROFILE", "")
+AMIP_MID_MONTH_SST_PROFILE = os.getenv("AMIP_MID_MONTH_SST_PROFILE", "")
 
 LAND_DATA_URL_10 = os.getenv(
     "LAND_DATA_URL_10", "s3://ICON_cycle3_ngc3028/landfraction/ngc3028_P1D_10.zarr/"

--- a/src/cbottle/config/environment.py
+++ b/src/cbottle/config/environment.py
@@ -23,6 +23,8 @@ SUBMIT_SCRIPT = os.getenv("SUBMIT_SCRIPT", "../../ord_scripts/submit_ord.sh")
 
 # data
 V6_ERA5_ZARR = os.getenv("V6_ERA5_ZARR", "s3://ERA5_hpx_zarrs/era5_hpx_6.zarr/")
+V6_ERA5_ZARR_PROFILE = os.getenv("V6_ERA5_ZARR_PROFILE", "")
+
 RAW_DATA_URL_7 = "s3://ICON_cycle3_ngc3028/ngc3028_PT30M_7.zarr/"
 RAW_DATA_URL_6 = os.getenv(
     "RAW_DATA_URL_6", "s3://ICON_cycle3_ngc3028/ngc3028_PT30M_6.zarr/"
@@ -66,6 +68,7 @@ AMIP_MID_MONTH_SST = os.getenv(
     "AMIP_MID_MONTH_SST",
     "s3://input4MIPs/tosbcs_input4MIPs_SSTsAndSeaIce_CMIP_PCMDI-AMIP-1-1-9_gn_187001-202212.nc",
 )
+AMIP_MID_MONTH_SST_PROFILE = os.getenv("AMIP_MID_MONTH_SST_PROFILE", "pbss")
 
 # project file
 PROJECT_ROOT = os.getenv(

--- a/src/cbottle/datasets/dataset_3d.py
+++ b/src/cbottle/datasets/dataset_3d.py
@@ -225,27 +225,16 @@ def combine_and_mask_frames(
 
     return frame_masker(out)
 
+def _transform(times: list[cftime.DatetimeGregorian], data_list: list[dict], *, encode_frame, frame_masker) -> dict:
+    frames = [encode_frame(time=t, data=d) for t, d in zip(times, data_list)]
 
-def get_transform(
-    encode_frame: Callable,
-    frame_masker: Optional[FrameMasker] = None,
-) -> Callable:
-    """
-    Encodes frames, and in the video case combines/masks them along the time dimension.
-    """
+    if len(frames) == 1:
+        return frames[0]
 
-    def transform(times: list[cftime.DatetimeGregorian], data_list: list[dict]) -> dict:
-        frames = [encode_frame(time=t, data=d) for t, d in zip(times, data_list)]
+    if frame_masker is None:
+        raise ValueError("Frame masker must be provided in video mode")
 
-        if len(frames) == 1:
-            return frames[0]
-
-        if frame_masker is None:
-            raise ValueError("Frame masker must be provided in video mode")
-
-        return combine_and_mask_frames(frames, frame_masker)
-
-    return transform
+    return combine_and_mask_frames(frames, frame_masker)
 
 
 def encode_task(
@@ -453,7 +442,7 @@ def _get_dataset_icon(
         is_land=land_fraction > 0,
     )
 
-    transform = get_transform(
+    transform = functools.partial(_transform,
         encode_frame=encode_frame,
         frame_masker=frame_masker,
     )
@@ -579,7 +568,7 @@ def _get_dataset_era5(
         encode_task, label, get_mean(), get_std(), sst_input=sst_input
     )
 
-    transform = get_transform(
+    transform = functools.partial(_transform,
         encode_frame=encode_frame,
         frame_masker=frame_masker,
     )
@@ -683,7 +672,7 @@ def get_amip_dataset(
     ]
     encode_frame = functools.partial(_encode_amip, label=LABELS.index("era5"))
 
-    transform = get_transform(
+    transform = functools.partial(_transform,
         encode_frame=encode_frame,
         frame_masker=frame_masker,
     )

--- a/src/cbottle/datasets/dataset_3d.py
+++ b/src/cbottle/datasets/dataset_3d.py
@@ -557,7 +557,10 @@ def _get_dataset_era5(
             HPX_LEVEL, pixel_order=earth2grid.healpix.PixelOrder.NEST
         )
         loaders.append(
-            AmipSSTDataset(grid, storage_options=get_storage_options("pbss"))
+            AmipSSTDataset(
+                grid,
+                storage_options=get_storage_options(config.AMIP_MID_MONTH_SST_PROFILE),
+            )
         )
 
     metadata = DATASET_METADATA["era5"]

--- a/src/cbottle/datasets/dataset_3d.py
+++ b/src/cbottle/datasets/dataset_3d.py
@@ -532,7 +532,7 @@ def _get_dataset_era5(
 ):
     target_data_loader = ZarrLoader(
         path=config.V6_ERA5_ZARR,
-        storage_options=get_storage_options("pdx"),
+        storage_options=config.V6_ERA5_ZARR_PROFILE,
         variables_3d=["u", "v", "t", "z"],
         variables_2d=[
             "sstk",

--- a/src/cbottle/datasets/dataset_3d.py
+++ b/src/cbottle/datasets/dataset_3d.py
@@ -225,7 +225,14 @@ def combine_and_mask_frames(
 
     return frame_masker(out)
 
-def _transform(times: list[cftime.DatetimeGregorian], data_list: list[dict], *, encode_frame, frame_masker) -> dict:
+
+def _transform(
+    times: list[cftime.DatetimeGregorian],
+    data_list: list[dict],
+    *,
+    encode_frame,
+    frame_masker,
+) -> dict:
     frames = [encode_frame(time=t, data=d) for t, d in zip(times, data_list)]
 
     if len(frames) == 1:
@@ -442,7 +449,8 @@ def _get_dataset_icon(
         is_land=land_fraction > 0,
     )
 
-    transform = functools.partial(_transform,
+    transform = functools.partial(
+        _transform,
         encode_frame=encode_frame,
         frame_masker=frame_masker,
     )
@@ -568,7 +576,8 @@ def _get_dataset_era5(
         encode_task, label, get_mean(), get_std(), sst_input=sst_input
     )
 
-    transform = functools.partial(_transform,
+    transform = functools.partial(
+        _transform,
         encode_frame=encode_frame,
         frame_masker=frame_masker,
     )
@@ -672,7 +681,8 @@ def get_amip_dataset(
     ]
     encode_frame = functools.partial(_encode_amip, label=LABELS.index("era5"))
 
-    transform = functools.partial(_transform,
+    transform = functools.partial(
+        _transform,
         encode_frame=encode_frame,
         frame_masker=frame_masker,
     )

--- a/tests/unit/test_merged_dataset.py
+++ b/tests/unit/test_merged_dataset.py
@@ -110,9 +110,9 @@ def test_time_merged_dataset(time_length, frame_step, window_stride):
     frames_per_window = (time_length - 1) * frame_step + 1
     valid_length = num_frames - frames_per_window + 1
     expected_windows = (valid_length + window_stride - 1) // window_stride
-    assert len(samples) == expected_windows, (
-        f"Expected {expected_windows} windows, got {len(samples)}"
-    )
+    assert (
+        len(samples) == expected_windows
+    ), f"Expected {expected_windows} windows, got {len(samples)}"
 
     for sample in samples:
         assert sample["target"].shape == (1, target_channels, time_length, num_pixels)
@@ -132,9 +132,9 @@ def test_time_merged_dataset(time_length, frame_step, window_stride):
     expected_starts = list(range(0, chunk_size * window_stride, window_stride))[
         :expected_windows
     ]
-    assert start_indices == expected_starts, (
-        "Without shuffle, windows should be in exact sequential order"
-    )
+    assert (
+        start_indices == expected_starts
+    ), "Without shuffle, windows should be in exact sequential order"
 
     # Test with shuffle=True
     dataset = TimeMergedDataset(
@@ -169,14 +169,14 @@ def test_time_merged_dataset(time_length, frame_step, window_stride):
         start_idx = int(sample["target"][0, 0, 0, 0].item())
         chunk2_indices.append(start_idx)
 
-    assert sorted(chunk1_indices) == sorted(chunk2_indices), (
-        "Chunks should contain same indices"
-    )
+    assert sorted(chunk1_indices) == sorted(
+        chunk2_indices
+    ), "Chunks should contain same indices"
 
     if len(chunk1_indices) != 1:
-        assert chunk1_indices != chunk2_indices, (
-            "Chunks should be in different orders when shuffled"
-        )
+        assert (
+            chunk1_indices != chunk2_indices
+        ), "Chunks should be in different orders when shuffled"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_merged_dataset.py
+++ b/tests/unit/test_merged_dataset.py
@@ -110,9 +110,9 @@ def test_time_merged_dataset(time_length, frame_step, window_stride):
     frames_per_window = (time_length - 1) * frame_step + 1
     valid_length = num_frames - frames_per_window + 1
     expected_windows = (valid_length + window_stride - 1) // window_stride
-    assert (
-        len(samples) == expected_windows
-    ), f"Expected {expected_windows} windows, got {len(samples)}"
+    assert len(samples) == expected_windows, (
+        f"Expected {expected_windows} windows, got {len(samples)}"
+    )
 
     for sample in samples:
         assert sample["target"].shape == (1, target_channels, time_length, num_pixels)
@@ -132,9 +132,9 @@ def test_time_merged_dataset(time_length, frame_step, window_stride):
     expected_starts = list(range(0, chunk_size * window_stride, window_stride))[
         :expected_windows
     ]
-    assert (
-        start_indices == expected_starts
-    ), "Without shuffle, windows should be in exact sequential order"
+    assert start_indices == expected_starts, (
+        "Without shuffle, windows should be in exact sequential order"
+    )
 
     # Test with shuffle=True
     dataset = TimeMergedDataset(
@@ -169,14 +169,14 @@ def test_time_merged_dataset(time_length, frame_step, window_stride):
         start_idx = int(sample["target"][0, 0, 0, 0].item())
         chunk2_indices.append(start_idx)
 
-    assert sorted(chunk1_indices) == sorted(
-        chunk2_indices
-    ), "Chunks should contain same indices"
+    assert sorted(chunk1_indices) == sorted(chunk2_indices), (
+        "Chunks should contain same indices"
+    )
 
     if len(chunk1_indices) != 1:
-        assert (
-            chunk1_indices != chunk2_indices
-        ), "Chunks should be in different orders when shuffled"
+        assert chunk1_indices != chunk2_indices, (
+            "Chunks should be in different orders when shuffled"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds AMIP setup instructions and removes reliance on loading ERA5 to set up the mask for the data in the AMIP loader