### PR TITLE
Patching zarr.open_group() for safer usage

### DIFF
--- a/src/cbottle/datasets/dataset_2d.py
+++ b/src/cbottle/datasets/dataset_2d.py
@@ -677,7 +677,7 @@ class HealpixDatasetV5(torch.utils.data.Dataset):
         else:
             storage_options = None
 
-        self.group = zarr.open_group(path, storage_options=storage_options)
+        self.group = zarr.open_group(path, storage_options=storage_options, mode="r")
         self.npix = self.group[self.variables_needed[0]].shape[-1]
         self.res_level = earth2grid.healpix.npix2level(self.npix)
         self.sst = sst
@@ -701,7 +701,9 @@ class HealpixDatasetV5(torch.utils.data.Dataset):
         else:
             storage_options = None
 
-        land_data = zarr.open_group(land_path, storage_options=storage_options)
+        land_data = zarr.open_group(
+            land_path, storage_options=storage_options, mode="r"
+        )
         self.land_fraction = land_data["land_fraction"][:]
 
         self._mean = torch.tensor(self.mean).unsqueeze(-1)

--- a/src/cbottle/datasets/dataset_3d.py
+++ b/src/cbottle/datasets/dataset_3d.py
@@ -435,6 +435,7 @@ def _get_dataset_icon(
     land_data = zarr.open_group(
         config.LAND_DATA_URL_6,
         storage_options=get_storage_options(config.LAND_DATA_PROFILE),
+        mode="r",
     )
     land_fraction = land_data["land_fraction"][:]
 

--- a/src/cbottle/datasets/zarr_loader.py
+++ b/src/cbottle/datasets/zarr_loader.py
@@ -77,9 +77,7 @@ class ZarrLoader:
 
         self.group = sync(
             zarr.api.asynchronous.open_group(
-                path,
-                storage_options=storage_options,
-                use_consolidated=True,
+                path, storage_options=storage_options, use_consolidated=True, mode="r"
             )
         )
 


### PR DESCRIPTION
Problem-solution: 
zarr.open_group() defaults to overwriting the entire directory if a valid .zgroup or .zmetadata files are not found. 
Since within this scope, only read-only permission is needed, the API call is scoped a bit to avoid unexpected behaviour.

The default mode is `mode=a` creates a zarr store in the place where it could not find it:  https://zarr.readthedocs.io/en/latest/api/zarr/index.html#zarr.open_group  