### PR TITLE
change default level in config to avoid superres inference bug

### DIFF
--- a/src/cbottle/config/models.py
+++ b/src/cbottle/config/models.py
@@ -25,7 +25,7 @@ class ModelConfigV1:
     condition_channels: int = 0
     time_length: int = 1
     label_dropout: float = 0.0
-    level: int = 6
+    level: int = 10
 
     # arguments for SongUnetHPX1024
     position_embed_channels: int = 20


### PR DESCRIPTION
This fixes the shape mismatch bug when running `python scripts/inference_multidiffusion.py` 