### PR TITLE
Including tas-only model and spatially masked image model training and inference

### DIFF
--- a/examples/tc_odds_ratio.py
+++ b/examples/tc_odds_ratio.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Minimal example: classifier-guided log-odds-ratio for a TC sample."""
+
+import cbottle.inference
+import matplotlib.pyplot as plt
+import pandas as pd
+import torch
+import warnings
+from cbottle.datasets.dataset_3d import get_dataset
+from cbottle.visualizations import visualize
+
+warnings.filterwarnings("ignore", message="Cannot do a zero-copy NCHW to NHWC")
+
+times = pd.date_range(start="2018-09-01T16:00:00", end="2018-09-01T16:00:00", freq="1h")
+lons = [-80]
+lats = [25]
+
+ds = get_dataset(dataset="amip")
+ds.set_times(times)
+loader = torch.utils.data.DataLoader(ds, batch_size=1)
+batch = next(iter(loader))
+
+CHECKPOINT_ROOT = (
+    "/lustre/fsw/portfolios/coreai/projects/coreai_climate_earth2/pmanshausen/"
+    "project-data/viddiff/training-runs/cbottle_3d_tc_public_layout/"
+)
+model = cbottle.inference.load("cbottle-3d-moe-tc", root=CHECKPOINT_ROOT)
+guidance_pixels = model.get_guidance_pixels(lons, lats)
+
+# Reduced-cost schedule so the example runs in a few minutes on one GPU.
+# For paper-accurate numbers drop the overrides; see CBottle3d.calculate_odds_ratio.
+results = model.calculate_odds_ratio(
+    batch,
+    guidance_pixels,
+    num_steps=18,
+    extra_steps_intervals=((15, 20, 5),),
+    divergence_samples=1,
+    compute_forward_divergences=False,
+    seed=0,
+)
+
+log_odds_ratio = (
+    (results["backward_no_guidance_gaussian_logp"] - results["backward_gaussian_logp"])
+    + (
+        results["backward_no_guidance_score_div_integral"]
+        - results["backward_score_div_integral"]
+    )
+    - results["backward_guidance_div_integral"]
+)
+print(f"log p_unguided / p_guided  ~  {log_odds_ratio:.2f}")
+
+sample = model._post_process(results["forward_latents"])
+visualize(sample[0, 0, 0].detach().cpu(), nest=True, region="carib")
+plt.savefig("tc_odds_ratio_sample.png", bbox_inches="tight", dpi=120)

--- a/examples/tc_odds_ratio.py
+++ b/examples/tc_odds_ratio.py
@@ -38,7 +38,7 @@ guidance_pixels = model.get_guidance_pixels(lons, lats)
 
 # Reduced-cost schedule so the example runs in a few minutes on one GPU.
 # For paper-accurate numbers drop the overrides; see CBottle3d.calculate_odds_ratio.
-results = model.calculate_odds_ratio(
+log_odds_ratio, forward_latents = model.calculate_odds_ratio(
     batch,
     guidance_pixels,
     num_steps=18,
@@ -48,16 +48,8 @@ results = model.calculate_odds_ratio(
     seed=0,
 )
 
-log_odds_ratio = (
-    (results["backward_no_guidance_gaussian_logp"] - results["backward_gaussian_logp"])
-    + (
-        results["backward_no_guidance_score_div_integral"]
-        - results["backward_score_div_integral"]
-    )
-    - results["backward_guidance_div_integral"]
-)
 print(f"log p_unguided / p_guided  ~  {log_odds_ratio:.2f}")
 
-sample = model._post_process(results["forward_latents"])
+sample = model._post_process(forward_latents)
 visualize(sample[0, 0, 0].detach().cpu(), nest=True, region="carib")
 plt.savefig("tc_odds_ratio_sample.png", bbox_inches="tight", dpi=120)

--- a/examples/tc_odds_ratio.py
+++ b/examples/tc_odds_ratio.py
@@ -33,11 +33,7 @@ ds.set_times(times)
 loader = torch.utils.data.DataLoader(ds, batch_size=1)
 batch = next(iter(loader))
 
-CHECKPOINT_ROOT = (
-    "/lustre/fsw/portfolios/coreai/projects/coreai_climate_earth2/pmanshausen/"
-    "project-data/viddiff/training-runs/cbottle_3d_tc_public_layout/"
-)
-model = cbottle.inference.load("cbottle-3d-moe-tc", root=CHECKPOINT_ROOT)
+model = cbottle.inference.load("cbottle-3d-moe-tc")
 guidance_pixels = model.get_guidance_pixels(lons, lats)
 
 # Reduced-cost schedule so the example runs in a few minutes on one GPU.

--- a/scripts/train_coarse.py
+++ b/scripts/train_coarse.py
@@ -51,6 +51,7 @@ from cbottle.datasets.dataset_3d import (
     MAX_CLASSES,
     get_batch_info,
     get_dataset,
+    _build_spatial_mask,
 )
 from cbottle.diagnostics import (
     sample_from_condition,
@@ -105,6 +106,8 @@ class TrainingLoop(loop.TrainingLoopBase):
     icon_chunk_size: int = 8
     era5_chunk_size: int = 48
     aimip_train_test_split: bool = False
+    tas_only_bbox: str = ""
+    tas_only_mask_path: str = ""
 
     # network
     network: SongUnetConfig = SongUnetConfig()
@@ -241,8 +244,36 @@ class TrainingLoop(loop.TrainingLoopBase):
                 # use a fixed unconditional generation task for test set
                 return FrameMasker(keep_frames=[])
 
+    def _get_spatial_mask(self):
+        bbox = None
+        if self.tas_only_bbox:
+            parts = [float(x) for x in self.tas_only_bbox.split(",")]
+            bbox = (parts[0], parts[1], parts[2], parts[3])
+        mask_path = self.tas_only_mask_path or None
+        return _build_spatial_mask(bbox=bbox, mask_path=mask_path)
+
     def get_dataset(self, train: bool):
         """Returns the final wrapped dataset for both image and video training."""
+        if self.variables == "tas_only":
+            rank = dist.get_rank()
+            world_size = dist.get_world_size()
+            spatial_mask = self._get_spatial_mask()
+            return get_dataset(
+                split="train" if train else "test",
+                dataset="tas_only",
+                rank=rank,
+                world_size=world_size,
+                sst_input=self.monthly_sst_input,
+                infinite=True,
+                shuffle=True,
+                chunk_size=self.era5_chunk_size,
+                time_step=self.time_step,
+                time_length=self.time_length,
+                frame_masker=self._get_frame_masker(train),
+                variable_config=VARIABLE_CONFIGS["tas_only"],
+                spatial_mask=spatial_mask,
+            )
+
         if self.with_era5 and dist.get_world_size() % 2 != 0:
             warnings.warn(
                 RuntimeWarning(
@@ -346,16 +377,24 @@ class TrainingLoop(loop.TrainingLoopBase):
         return D
 
     def _curry_net_discard_classifier(self, net, batch):
+        spatial_mask = batch.get("spatial_mask")
+        if spatial_mask is not None:
+            sm = spatial_mask[0] if spatial_mask.dim() > 1 else spatial_mask
+
         def D(x, t):
+            x_in = x * sm if spatial_mask is not None else x
             out = net(
-                x.to(memory_format=self.memory_format),
+                x_in.to(memory_format=self.memory_format),
                 torch.as_tensor(t, device=x.device),
                 batch["labels"],
                 condition=batch["condition"],
                 day_of_year=batch["day_of_year"],
                 second_of_day=batch["second_of_day"],
             )
-            return out.out
+            result = out.out
+            if spatial_mask is not None:
+                result = result * sm
+            return result
 
         return D
 
@@ -364,6 +403,7 @@ class TrainingLoop(loop.TrainingLoopBase):
             self._curry_net(self.ddp, batch),
             target,
             classifier_labels=batch.get("classifier_labels"),
+            spatial_mask=batch.get("spatial_mask"),
         )
         training_stats.report("Loss/denoising", loss.denoising)
         self._train_sigma_metric.update(loss.sigma, loss.denoising)
@@ -377,6 +417,7 @@ class TrainingLoop(loop.TrainingLoopBase):
             self._curry_net(self.ddp, batch),
             target,
             classifier_labels=batch.get("classifier_labels"),
+            spatial_mask=batch.get("spatial_mask"),
         )
         training_stats.report("Loss/test_denoising", loss.denoising)
         self._test_sigma_metric.update(loss.sigma, loss.denoising)
@@ -472,6 +513,10 @@ class TrainingLoop(loop.TrainingLoopBase):
         with self._disable_parameter_gradients(net):
             target = batch["target"]
             mask = ~torch.isnan(target)
+            spatial_mask = batch.get("spatial_mask")
+            if spatial_mask is not None:
+                sm = spatial_mask[0] if spatial_mask.dim() > 1 else spatial_mask
+                mask = mask & (sm != 0)
             log_prob, _ = cbottle.likelihood.log_prob(
                 # TODO replace with denoiser classifier?
                 self._curry_net_discard_classifier(net, batch),

--- a/src/cbottle/config/environment.py
+++ b/src/cbottle/config/environment.py
@@ -76,3 +76,16 @@ CHECKPOINT_ROOT = os.getenv(
 IBTRACS_DATA_PATH = os.getenv(
     "IBTRACS_DATA_PATH", os.path.join(CACHE_DIR, "ibtracs.nc")
 )
+
+RCLONE_CONFIG = os.getenv("RCLONE_CONFIG", "")
+
+# Job submission
+SUBMIT_ACCOUNT = os.getenv("SUBMIT_ACCOUNT", "")
+SUBMIT_SCRIPT = os.getenv("SUBMIT_SCRIPT", "")
+
+# tas-only netCDF training data
+TAS_ONLY_NETCDF_DIR = os.getenv(
+    "TAS_ONLY_NETCDF_DIR",
+    "/lustre/fs1/portfolios/coreai/projects/coreai_climate_earth2/"
+    "tge/climate_bottle/inferences/v6data-mChan192/MoE",
+)

--- a/src/cbottle/datasets/dataset_3d.py
+++ b/src/cbottle/datasets/dataset_3d.py
@@ -51,6 +51,7 @@ import cftime
 import earth2grid
 import numpy as np
 import pandas as pd
+import xarray as xr
 import torch
 from cbottle.datasets import catalog
 from cbottle.datasets.base import BatchInfo, TimeUnit
@@ -64,7 +65,9 @@ from cbottle.datasets.dataset_2d import (
 from cbottle.datasets.ibtracs import IBTracs
 from cbottle.datasets.amip_sst_loader import AmipSSTLoader, AImip_SSTLoader
 from cbottle.datasets.merged_dataset import TimeMergedDataset, TimeMergedMapStyle
+from cbottle.datasets.netcdf_tas_loader import NetCDFTasLoader
 from cbottle.datasets.zarr_loader import ZarrLoader
+from cbottle.config import environment as config
 from cbottle.training.video.frame_masker import FrameMasker
 
 NO_LEVEL = -1
@@ -141,6 +144,11 @@ VARIABLE_CONFIGS["aimip"] = VariableConfig(
         "2d",
     ],
 )
+VARIABLE_CONFIGS["tas_only"] = VariableConfig(
+    levels=[],
+    variables_3d=[],
+    variables_2d=["tas"],
+)
 _default_config = VARIABLE_CONFIGS["default"]
 
 
@@ -183,6 +191,13 @@ DATASET_METADATA: dict[str, DatasetMetadata] = {
         name="amip",
         start="1940-01-01",
         end="2021-12-31",
+        time_step=1,
+        time_unit=TimeUnit.HOUR,
+    ),
+    "tas_only": DatasetMetadata(
+        name="tas_only",
+        start="1940-01-01",
+        end="2020-12-31",
         time_step=1,
         time_unit=TimeUnit.HOUR,
     ),
@@ -474,6 +489,83 @@ def _encode_amip(
     return out
 
 
+def _build_spatial_mask(
+    bbox: tuple[float, float, float, float] | None = None,
+    mask_path: str | None = None,
+) -> torch.Tensor:
+    """Build a spatial mask in HEALPIX_PAD_XY order."""
+    grid = earth2grid.healpix.Grid(
+        HPX_LEVEL, pixel_order=earth2grid.healpix.HEALPIX_PAD_XY
+    )
+    lat = torch.tensor(grid.lat)
+    lon = torch.tensor(grid.lon)
+
+    if mask_path is not None:
+        ds = xr.open_dataset(mask_path)
+        mask_var = [v for v in ds.data_vars if ds[v].dims == ("pix",)]
+        if not mask_var:
+            raise ValueError(f"No 1D pix variable found in {mask_path}")
+        mask_ring = torch.tensor(ds[mask_var[0]].values, dtype=torch.float32)
+        ds.close()
+        ring_grid = earth2grid.healpix.Grid(
+            HPX_LEVEL, pixel_order=earth2grid.healpix.PixelOrder.RING
+        )
+        mask = ring_grid.reorder(earth2grid.healpix.HEALPIX_PAD_XY, mask_ring)
+    elif bbox is not None:
+        lat_min, lat_max, lon_min, lon_max = bbox
+        mask = (
+            (lat >= lat_min) & (lat <= lat_max) & (lon >= lon_min) & (lon <= lon_max)
+        ).float()
+    else:
+        mask = torch.ones(len(lat), dtype=torch.float32)
+
+    return mask
+
+
+def _encode_netcdf_tas(
+    time: cftime.DatetimeGregorian,
+    data: dict[tuple[str, int | None], np.ndarray],
+    *,
+    label: int,
+    mean: np.ndarray,
+    scale: np.ndarray,
+    variable_config: VariableConfig,
+    spatial_mask: torch.Tensor,
+):
+    """Encode a single tas frame from netCDF data with SST condition and mask."""
+    labels = torch.nn.functional.one_hot(torch.tensor(label), num_classes=MAX_CLASSES)
+    mean = mean[:, np.newaxis, np.newaxis]
+    scale = scale[:, np.newaxis, np.newaxis]
+    arr = _collect_fields(_get_index(variable_config), data)
+    arr = (arr - mean) / scale
+
+    def reorder(x):
+        x = torch.as_tensor(x)
+        return earth2grid.healpix.reorder(
+            x, earth2grid.healpix.PixelOrder.NEST, earth2grid.healpix.HEALPIX_PAD_XY
+        ).to(torch.float32)
+
+    target = reorder(arr) * spatial_mask
+    sst = data[("tosbcs", NO_LEVEL)]
+    cond = reorder(encode_sst(sst))
+
+    day_start = time.replace(hour=0, minute=0, second=0)
+    year_start = day_start.replace(month=1, day=1)
+    second_of_day = (time - day_start) / datetime.timedelta(seconds=1)
+    day_of_year = (time - year_start) / datetime.timedelta(seconds=86400)
+
+    out = {
+        "target": target,
+        "labels": labels,
+        "condition": cond,
+        "second_of_day": torch.tensor([second_of_day]),
+        "day_of_year": torch.tensor([day_of_year]),
+        "spatial_mask": spatial_mask,
+    }
+    out["timestamp"] = _cftime_to_timestamp(time)
+    return out
+
+
 def _loader_from_catalog(dataset: catalog._Zarr, **kwargs) -> ZarrLoader:
     return ZarrLoader(
         path=dataset.path, storage_options=dataset.storage_options, **kwargs
@@ -598,6 +690,15 @@ def _get_loaders(
                     sst_offset=sst_offset,
                 )
             ]
+    elif dataset == "tas_only":
+        loaders = [
+            NetCDFTasLoader(directory=config.TAS_ONLY_NETCDF_DIR),
+        ]
+        if sst_input:
+            grid = earth2grid.healpix.Grid(
+                HPX_LEVEL, pixel_order=earth2grid.healpix.PixelOrder.NEST
+            )
+            loaders.append(AmipSSTLoader(grid, sst_offset=sst_offset))
 
     else:
         raise ValueError(f"Unknown dataset: {dataset}")
@@ -610,6 +711,7 @@ def _get_frame_encoder(
     *,
     sst_input: bool = True,
     variable_config: VariableConfig = _default_config,
+    spatial_mask: torch.Tensor | None = None,
 ):
     """Get the appropriate transform function for a given dataset.
 
@@ -656,6 +758,17 @@ def _get_frame_encoder(
         encode_frame = functools.partial(
             _encode_amip, label=LABELS.index("era5"), variable_config=variable_config
         )
+    elif dataset == "tas_only":
+        if spatial_mask is None:
+            spatial_mask = _build_spatial_mask()
+        encode_frame = functools.partial(
+            _encode_netcdf_tas,
+            label=LABELS.index("era5"),
+            mean=get_mean(variable_config),
+            scale=get_std(variable_config),
+            variable_config=variable_config,
+            spatial_mask=spatial_mask,
+        )
 
     else:
         raise ValueError(f"Unknown dataset: {dataset}")
@@ -682,6 +795,9 @@ def _get_splits(dataset: str):
         # AMIP doesn't have train/test split, use all times
         train_times = valid_times
         test_times = valid_times
+    elif dataset == "tas_only":
+        train_times = valid_times[valid_times < "2015"]
+        test_times = valid_times[valid_times >= "2015"]
     else:
         raise ValueError(f"Unknown dataset: {dataset}")
 
@@ -704,6 +820,7 @@ def get_dataset(
     frame_masker: Optional[FrameMasker] = None,
     variable_config: VariableConfig = _default_config,
     map_style: bool = False,
+    spatial_mask: torch.Tensor | None = None,
     sst_offset: float = 0.0,
 ) -> TimeMergedDataset | TimeMergedMapStyle:
     # Get the appropriate loaders for the dataset
@@ -737,6 +854,7 @@ def get_dataset(
             dataset,
             sst_input=sst_input,
             variable_config=variable_config,
+            spatial_mask=spatial_mask,
         ),
         frame_masker=frame_masker,
     )

--- a/src/cbottle/datasets/netcdf_tas_loader.py
+++ b/src/cbottle/datasets/netcdf_tas_loader.py
@@ -1,0 +1,91 @@
+import asyncio
+import glob
+import logging
+from collections import defaultdict
+
+import earth2grid
+import numpy as np
+import pandas as pd
+import torch
+import xarray as xr
+
+NO_LEVEL = -1
+HPX_LEVEL = 6
+
+logger = logging.getLogger(__name__)
+
+
+class NetCDFTasLoader:
+    """Load tas from a directory of netCDF files produced by cbottle inference.
+
+    Files are assumed to be HEALPix level 6, RING order (as written by
+    ``NetCDFWriter``). Data is reordered to NEST on output so it matches the
+    convention of the existing zarr loaders used in ``dataset_3d``.
+
+    All file handles are kept open and the reorder matrix is precomputed so that
+    ``sel_time`` only does numpy indexing + a sparse matmul.
+    """
+
+    def __init__(self, directory: str, variable_name: str = "tas"):
+        self.variable_name = variable_name
+        nc_files = sorted(glob.glob(f"{directory}/*.nc"))
+        if not nc_files:
+            raise FileNotFoundError(f"No .nc files found in {directory}")
+
+        logger.info("Scanning %d netCDF files in %s", len(nc_files), directory)
+
+        all_times = []
+        self._file_index: list[tuple[str, int]] = []
+        self._open_datasets: dict[str, xr.Dataset] = {}
+
+        for path in nc_files:
+            ds = xr.open_dataset(path, decode_times=True)
+            self._open_datasets[path] = ds
+            file_times = pd.DatetimeIndex(ds["time"].values)
+            for local_idx, t in enumerate(file_times):
+                all_times.append(t)
+                self._file_index.append((path, local_idx))
+
+        self.times = pd.DatetimeIndex(all_times).sort_values()
+        sort_order = pd.DatetimeIndex(all_times).argsort()
+        self._file_index = [self._file_index[i] for i in sort_order]
+        self._time_to_pos = {t: i for i, t in enumerate(self.times)}
+
+        ring_grid = earth2grid.healpix.Grid(
+            HPX_LEVEL, pixel_order=earth2grid.healpix.PixelOrder.RING
+        )
+        nest_grid = earth2grid.healpix.Grid(
+            HPX_LEVEL, pixel_order=earth2grid.healpix.PixelOrder.NEST
+        )
+        self._ring_to_nest = ring_grid.get_bilinear_regridder_to(
+            nest_grid.lat, nest_grid.lon
+        ).float()
+
+    def _load_slice(self, times) -> dict[tuple[str, int], np.ndarray]:
+        requests: dict[str, list[tuple[int, int]]] = defaultdict(list)
+        for out_idx, t in enumerate(times):
+            pos = self._time_to_pos.get(t)
+            if pos is None:
+                pos = self.times.get_indexer([t], method="nearest")[0]
+                if pos == -1:
+                    raise KeyError(f"Time {t} not found in loader")
+            path, local_idx = self._file_index[pos]
+            requests[path].append((out_idx, local_idx))
+
+        npix = 12 * 4**HPX_LEVEL
+        out = np.empty((len(times), npix), dtype=np.float32)
+
+        for path, indices in requests.items():
+            ds = self._open_datasets[path]
+            local_idxs = [li for _, li in indices]
+            out_idxs = [oi for oi, _ in indices]
+            chunk = (
+                ds[self.variable_name].isel(time=local_idxs).values.astype(np.float32)
+            )
+            chunk_nest = self._ring_to_nest(torch.from_numpy(chunk).float()).numpy()
+            out[out_idxs] = chunk_nest
+
+        return {(self.variable_name, NO_LEVEL): out}
+
+    async def sel_time(self, times) -> dict[tuple[str, int], np.ndarray]:
+        return await asyncio.to_thread(self._load_slice, times)

--- a/src/cbottle/datasets/netcdf_tas_loader.py
+++ b/src/cbottle/datasets/netcdf_tas_loader.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import asyncio
 import glob
 import logging

--- a/src/cbottle/diagnostics.py
+++ b/src/cbottle/diagnostics.py
@@ -166,6 +166,7 @@ def sample_from_condition(
         batch.pop("target")
         labels = batch.pop("labels")
         batch.pop("mask", None)
+        batch.pop("spatial_mask", None)
 
         if regression:
             out = call_regression(

--- a/src/cbottle/inference/__init__.py
+++ b/src/cbottle/inference/__init__.py
@@ -24,9 +24,11 @@ import numpy as np
 import torch
 import earth2grid
 from earth2grid import healpix
+from tqdm.auto import tqdm
 from typing import Callable, Literal, Sequence
 import dataclasses
 import logging
+import warnings
 from scipy.signal.windows import kaiser_bessel_derived
 
 import cbottle.denoiser_factories
@@ -41,10 +43,11 @@ from cbottle.diffusion_samplers import (
 from cbottle.datasets import base
 from cbottle.odds_ratio import (
     DivergenceTracker,
+    OddsRatioResult,
     _make_reverse_aware_sampler,
     calculate_divergence_integral,
     calculate_gaussian_logp,
-    classifier_bce_guidance,
+    classifier_guidance,
     default_sigma_schedule,
 )
 
@@ -153,11 +156,7 @@ class CBottle3d:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
         self.net = self.net.to(device)
-        # Duck-type: test helpers use plain callables as separate_classifier
-        # (no .to attribute). Only move real nn.Modules / tensors.
-        if self.separate_classifier is not None and hasattr(
-            self.separate_classifier, "to"
-        ):
+        if self.separate_classifier is not None:
             self.separate_classifier = self.separate_classifier.to(device)
 
     @classmethod
@@ -563,19 +562,40 @@ class CBottle3d:
         bf16=True,
         pre_generated_latents: torch.Tensor | None = None,
         return_untransformed: bool = False,
-        guidance_fn: Callable | None = None,
-        sampler: Callable | None = None,
+        guidance_fn: Callable[
+            [
+                torch.Tensor | None,
+                torch.Tensor | None,
+                torch.Tensor,
+                torch.Tensor,
+                torch.Tensor,
+            ],
+            torch.Tensor,
+        ]
+        | None = None,
+        sampler: Callable[..., torch.Tensor] | None = None,
     ):
         """
         Args:
-
-            guidance_pixels: Either the pixel index of ``self.input_grid``` where the
-                TCs are desired. 0<= guidance_pixels < 12 * nside ^2. Or the enitre HPX
-                tensor already set. If None, no guidance used.
-            guidance_scale: float = 0.03,
-            guidance_fn: Optional callable replacing ``cbottle.denoiser_factories.get_guidance``.
-            sampler: Optional callable replacing ``edm_sampler_from_sigma``.
-
+            guidance_pixels: Either the pixel index of ``self.input_grid`` where
+                the TCs are desired (``0 <= guidance_pixels < 12 * nside ** 2``)
+                or the entire HPX tensor already set. If ``None``, no guidance.
+            guidance_scale: Multiplier on the per-step guidance vector returned
+                by ``guidance_fn``.
+            guidance_fn: Optional per-step guidance hook replacing
+                ``cbottle.denoiser_factories.get_guidance``. Called once per
+                sampler step with positional args
+                ``(guidance_data, logits, x_hat, denoised, t_hat)`` and must
+                return a ``torch.Tensor`` of the
+                same shape as ``x_hat`` representing the *unscaled* guidance
+                vector. The caller adds ``guidance_scale * d_guide`` to the
+                drift, so ``guidance_fn`` is responsible only for the gradient
+                direction and any sigma-schedule weighting it applies
+                internally.
+            sampler: Optional EDM sampler replacing ``edm_sampler_from_sigma``.
+                Called as ``sampler(D, xT, randn_like=..., sigma_min=...,
+                sigma_max=..., num_steps=..., time_stepper=...)`` and must
+                return a ``torch.Tensor`` of the same shape as ``xT``.
         """
         if batch["target"].device != self.device:
             batch = self._move_to_device(batch)
@@ -756,10 +776,32 @@ class CBottle3d:
         self,
         batch: dict,
         guidance_pixels: torch.Tensor,
+        **kwargs,
+    ) -> tuple[float, torch.Tensor]:
+        """Compute classifier-guided ``(log_odds_ratio, forward_latents)``.
+
+        Thin wrapper over :meth:`_calculate_odds_ratio_full`; forwards
+        ``**kwargs`` verbatim. Always runs both backward phases (so that
+        ``log_odds_ratio`` is defined). For per-phase divergence integrals,
+        Gaussian logps, and the backward latents, call
+        :meth:`_calculate_odds_ratio_full` directly.
+        """
+        kwargs.setdefault("run_backward", True)
+        if not kwargs["run_backward"]:
+            raise ValueError(
+                "calculate_odds_ratio requires run_backward=True; "
+                "use _calculate_odds_ratio_full for forward-only mode."
+            )
+        result = self._calculate_odds_ratio_full(batch, guidance_pixels, **kwargs)
+        return result.log_odds_ratio, result.forward_latents
+
+    def _calculate_odds_ratio_full(
+        self,
+        batch: dict,
+        guidance_pixels: torch.Tensor,
         *,
         num_steps: int = 36,
         sigma_min: float = 0.002,
-        sigma_max: float = 200.0,
         rho: float = 7.0,
         extra_steps_intervals: "Sequence[tuple[float, float, int]]" = ((15, 20, 25),),
         guidance_scale: float = 64.0 * 20.0,
@@ -772,14 +814,27 @@ class CBottle3d:
         forward_guidance: bool = True,
         compute_forward_divergences: bool = True,
         seed: int | None = None,
-    ) -> dict:
+    ) -> OddsRatioResult:
         """Compute log-odds-ratio ingredients for ``batch`` under classifier guidance.
 
-        Runs a forward pass (``batch["target"]`` -> noise) and, when
-        ``run_backward=True``, two backward passes (noise -> sample, with and
-        without classifier guidance). Each phase records Hutchinson-estimated
-        divergence integrals; the backward samples additionally get a Gaussian
-        reference logp. The log-odds-ratio is recovered as::
+        Phase naming follows the script convention, NOT standard diffusion
+        terminology:
+
+        - **"forward"** = decoding direction (``reverse=False``,
+          ``start_latents=None``). Standard EDM sampler: starts from Gaussian
+          noise at ``sigma_max`` and integrates down to ``sigma=0`` to produce
+          a clean sample (``forward_latents``).
+        - **"backward"** = encoding direction (``reverse=True``,
+          ``start_latents=forward_latents``). Schedule is flipped to ascend
+          from ``sigma_min`` to ``sigma_max``, with the tail restored to the
+          raw ``sigma_max`` so the Gaussian reference is well-defined. The
+          starting latents are overridden with ``forward_latents`` from the
+          forward phase, so the run encodes the forward sample back to noise
+          (``backward_latents`` / ``backward_no_guidance_latents``). The
+          Gaussian logp of these encoded noise tensors under
+          ``N(0, sigma_max^2 I)`` provides the reference for the odds ratio.
+
+        The ``log_odds_ratio`` property combines only the backward fields::
 
             log p_unguided / p_guided
             ~= (backward_no_guidance_gaussian_logp - backward_gaussian_logp)
@@ -789,41 +844,67 @@ class CBottle3d:
         For an unguided true log-likelihood via the probability-flow ODE use
         :func:`cbottle.likelihood.log_prob` instead. Defaults match the TC
         paper configuration (36 steps densified to 61 in the [15,20] sigma
-        window, ``guidance_scale = 64 * 20``).
+        window, ``guidance_scale = 64 * 20``). Note that the maximum sigma is
+        always ``self.sigma_max`` (the value the model was constructed with):
+        ``xT`` seeding, the schedule endpoint, and the Gaussian reference
+        logp must all agree, so it is not exposed as a kwarg here.
 
         Args:
             batch: Data batch (same format as :meth:`sample`).
-            guidance_pixels: Guidance pixel index tensor; see
-                :meth:`get_guidance_pixels`.
+            guidance_pixels: 1-D tensor ``(N,)`` of HPX pixel indices on
+                ``self.classifier_grid`` (level 3, HEALPIX_PAD_XY) where TCs
+                are desired. Build via :meth:`get_guidance_pixels`.
+            num_steps, sigma_min, rho, extra_steps_intervals: Parameters of
+                the *custom* odds-ratio schedule built by
+                :func:`cbottle.odds_ratio._create_custom_time_steps`. These
+                are intentionally separate from ``self.num_steps`` /
+                ``self.sigma_min`` (which govern the default EDM sampler that
+                ``_sample_with_latents`` falls back on) and may be tuned
+                independently to densify the guidance window.
             run_backward: If ``False``, only run the forward pass.
             forward_guidance: If ``False``, forward pass runs without the
                 classifier guidance gradient.
             compute_forward_divergences: If ``False``, skip Hutchinson probes
                 on the forward pass.
             seed: If set, seeds the initial Gaussian noise for the forward
-                phase so the method is deterministic run-to-run. The two
-                backward phases use the forward latents as their starting
-                point, so they inherit this seed implicitly. Hutchinson probes
+                phase so the method is deterministic run-to-run. Hutchinson probes
                 are always deterministically seeded per step.
 
         Returns:
-            Dict with scalar divergence integrals (``*_div_integral``), two
-            Gaussian reference logps (``*_gaussian_logp``), ``initial_log_prob``
-            (scalar log p of the forward-step-0 xT under N(0, sigma_max^2)),
-            and tensors for the raw untransformed phase outputs (``*_latents``).
-            Callers running many batches should drop the tensor keys before
-            accumulating.
+            :class:`~cbottle.odds_ratio.OddsRatioResult` with per-phase
+            divergence integrals, Gaussian reference logps, the forward
+            ``initial_log_prob``, and the raw untransformed phase latents.
+            Use ``result.log_odds_ratio`` to recover the combined scalar.
+
+        Note:
+            Only ``batch["target"].shape[0] == 1`` is supported. The
+            Hutchinson divergence trace and Gaussian reference logp are
+            both reduced as a single multivariate Gaussian over the whole
+            sample tensor, and the second-order autograd path through the
+            denoiser is GPU-memory-bound -- larger batches OOM in practice.
         """
         if batch["target"].device != self.device:
             batch = self._move_to_device(batch)
 
-        schedule_kwargs = dict(
-            num_steps=num_steps,
-            sigma_min=sigma_min,
-            sigma_max=sigma_max,
-            rho=rho,
-            extra_steps_intervals=extra_steps_intervals,
-        )
+        if batch["target"].shape[0] != 1:
+            raise ValueError(
+                f"_calculate_odds_ratio_full only supports batch_size=1; "
+                f"got batch['target'].shape={tuple(batch['target'].shape)}. "
+                f"Loop over batches in the caller."
+            )
+
+        # The custom odds-ratio sampler is Euler-only; the model-level
+        # time_stepper is ignored here. Warn once so callers who built the
+        # model with time_stepper="heun" don't silently get a different
+        # integrator than sample() would use.
+        if self.time_stepper != "euler":
+            warnings.warn(
+                f"calculate_odds_ratio uses an Euler-only custom sampler; "
+                f"model.time_stepper={self.time_stepper!r} is not honored. "
+                f"Results will differ from sample() on this model.",
+                stacklevel=2,
+            )
+
         sigma_schedule_fn = lambda t_hat: default_sigma_schedule(  # noqa: E731
             t_hat, guidance_on=guidance_on, guidance_off=guidance_off
         )
@@ -841,7 +922,7 @@ class CBottle3d:
                 f"(reverse={reverse}, guidance={compute_guidance})"
             )
             if compute_guidance:
-                guidance_fn = classifier_bce_guidance
+                guidance_fn = classifier_guidance
                 guidance_pixels_eff = guidance_pixels
                 scale = guidance_scale
                 tracker_scale = guidance_scale
@@ -857,7 +938,7 @@ class CBottle3d:
             tracker = DivergenceTracker(
                 guidance_fn=guidance_fn,
                 guidance_scale=tracker_scale,
-                sigma_max=sigma_max,
+                sigma_max=self.sigma_max,
                 divergence_samples=divergence_samples,
                 phase=phase,
                 compute_score_div=compute_divergences,
@@ -867,8 +948,16 @@ class CBottle3d:
             sampler_func = _make_reverse_aware_sampler(
                 reverse=reverse,
                 start_latents=start_latents,
-                progress_desc=f"calculate_odds_ratio[{phase}]",
-                **schedule_kwargs,
+                num_steps=num_steps,
+                sigma_min=sigma_min,
+                sigma_max=self.sigma_max,
+                rho=rho,
+                extra_steps_intervals=extra_steps_intervals,
+                progress_wrapper=lambda it, _phase=phase: tqdm(
+                    it,
+                    desc=f"calculate_odds_ratio[{_phase}]",
+                    leave=False,
+                ),
             )
 
             _processed, _coords, raw = self._sample_with_latents(
@@ -900,15 +989,15 @@ class CBottle3d:
             forward_tracker.data, "score_divergence", "forward"
         )
 
-        results: dict = {
-            "forward_guidance_div_integral": float(forward_guidance_div_integral),
-            "forward_score_div_integral": float(forward_score_div_integral),
-            "initial_log_prob": forward_tracker.initial_log_prob,
-            "forward_latents": forward_latents,
-        }
+        result = OddsRatioResult(
+            forward_guidance_div_integral=float(forward_guidance_div_integral),
+            forward_score_div_integral=float(forward_score_div_integral),
+            initial_log_prob=forward_tracker.initial_log_prob,
+            forward_latents=forward_latents,
+        )
 
         if not run_backward:
-            return results
+            return result
 
         # ---- Backward with guidance -----------------------------------------
         backward_latents, backward_tracker = _run_phase(
@@ -923,7 +1012,9 @@ class CBottle3d:
         backward_score_div_integral = calculate_divergence_integral(
             backward_tracker.data, "score_divergence", "backward"
         )
-        backward_gaussian_logp = calculate_gaussian_logp(backward_latents, sigma_max)
+        backward_gaussian_logp = calculate_gaussian_logp(
+            backward_latents, self.sigma_max
+        )
 
         # ---- Backward without guidance --------------------------------------
         (
@@ -942,28 +1033,24 @@ class CBottle3d:
             backward_no_guidance_tracker.data, "score_divergence", "backward"
         )
         backward_no_guidance_gaussian_logp = calculate_gaussian_logp(
-            backward_no_guidance_latents, sigma_max
+            backward_no_guidance_latents, self.sigma_max
         )
 
-        results.update(
-            {
-                "backward_guidance_div_integral": float(backward_guidance_div_integral),
-                "backward_score_div_integral": float(backward_score_div_integral),
-                "backward_gaussian_logp": float(backward_gaussian_logp),
-                "backward_no_guidance_guidance_div_integral": float(
-                    backward_no_guidance_guidance_div_integral
-                ),
-                "backward_no_guidance_score_div_integral": float(
-                    backward_no_guidance_score_div_integral
-                ),
-                "backward_no_guidance_gaussian_logp": float(
-                    backward_no_guidance_gaussian_logp
-                ),
-                "backward_latents": backward_latents,
-                "backward_no_guidance_latents": backward_no_guidance_latents,
-            }
+        result.backward_guidance_div_integral = float(backward_guidance_div_integral)
+        result.backward_score_div_integral = float(backward_score_div_integral)
+        result.backward_gaussian_logp = float(backward_gaussian_logp)
+        result.backward_latents = backward_latents
+        result.backward_no_guidance_guidance_div_integral = float(
+            backward_no_guidance_guidance_div_integral
         )
-        return results
+        result.backward_no_guidance_score_div_integral = float(
+            backward_no_guidance_score_div_integral
+        )
+        result.backward_no_guidance_gaussian_logp = float(
+            backward_no_guidance_gaussian_logp
+        )
+        result.backward_no_guidance_latents = backward_no_guidance_latents
+        return result
 
     def sample_for_superresolution(
         self,

--- a/src/cbottle/inference/__init__.py
+++ b/src/cbottle/inference/__init__.py
@@ -40,11 +40,11 @@ from cbottle.diffusion_samplers import (
 )
 from cbottle.datasets import base
 from cbottle.odds_ratio import (
-    ClassifierGuidanceStrategy,
     DivergenceTracker,
     _make_reverse_aware_sampler,
     calculate_divergence_integral,
     calculate_gaussian_logp,
+    classifier_bce_guidance,
     default_sigma_schedule,
 )
 
@@ -841,21 +841,21 @@ class CBottle3d:
                 f"(reverse={reverse}, guidance={compute_guidance})"
             )
             if compute_guidance:
-                strategy = ClassifierGuidanceStrategy()
+                guidance_fn = classifier_bce_guidance
                 guidance_pixels_eff = guidance_pixels
                 scale = guidance_scale
                 tracker_scale = guidance_scale
             else:
-                strategy = None
+                guidance_fn = None
                 guidance_pixels_eff = None
                 scale = 0.0
-                # With no guidance strategy the scale is unused inside the
-                # tracker (it only multiplies a zero vector); pass 0 for
-                # clarity rather than the caller's scale.
+                # With no guidance_fn the scale is unused inside the tracker
+                # (it only multiplies a zero vector); pass 0 for clarity
+                # rather than the caller's scale.
                 tracker_scale = 0.0
 
             tracker = DivergenceTracker(
-                guidance_strategy=strategy,
+                guidance_fn=guidance_fn,
                 guidance_scale=tracker_scale,
                 sigma_max=sigma_max,
                 divergence_samples=divergence_samples,

--- a/src/cbottle/inference/__init__.py
+++ b/src/cbottle/inference/__init__.py
@@ -24,7 +24,7 @@ import numpy as np
 import torch
 import earth2grid
 from earth2grid import healpix
-from typing import Literal
+from typing import Callable, Literal, Sequence
 import dataclasses
 import logging
 from scipy.signal.windows import kaiser_bessel_derived
@@ -39,6 +39,14 @@ from cbottle.diffusion_samplers import (
     StackedRandomGenerator,
 )
 from cbottle.datasets import base
+from cbottle.odds_ratio import (
+    ClassifierGuidanceStrategy,
+    DivergenceTracker,
+    _make_reverse_aware_sampler,
+    calculate_divergence_integral,
+    calculate_gaussian_logp,
+    default_sigma_schedule,
+)
 
 from cbottle.datasets.dataset_2d import HealpixDatasetV5, LABELS
 from cbottle.config import environment
@@ -114,7 +122,8 @@ class CBottle3d:
             time_stepper: Which time stepper to use (heun, euler)
             channels_last: Whether to convert input and model to channels_last
             torch_compile: Whether to compile the model with torch.compile
-            device: Device to move models to
+            device: Device to move models to. If None (default), auto-detects
+                "cuda" when available else "cpu".
         """
         self.net = net
         self.separate_classifier = separate_classifier
@@ -141,10 +150,14 @@ class CBottle3d:
 
     def _move_models_to_device(self, device: str | None):
         if device is None:
-            return
+            device = "cuda" if torch.cuda.is_available() else "cpu"
 
         self.net = self.net.to(device)
-        if self.separate_classifier is not None:
+        # Duck-type: test helpers use plain callables as separate_classifier
+        # (no .to attribute). Only move real nn.Modules / tensors.
+        if self.separate_classifier is not None and hasattr(
+            self.separate_classifier, "to"
+        ):
             self.separate_classifier = self.separate_classifier.to(device)
 
     @classmethod
@@ -550,6 +563,8 @@ class CBottle3d:
         bf16=True,
         pre_generated_latents: torch.Tensor | None = None,
         return_untransformed: bool = False,
+        guidance_fn: Callable | None = None,
+        sampler: Callable | None = None,
     ):
         """
         Args:
@@ -558,6 +573,8 @@ class CBottle3d:
                 TCs are desired. 0<= guidance_pixels < 12 * nside ^2. Or the enitre HPX
                 tensor already set. If None, no guidance used.
             guidance_scale: float = 0.03,
+            guidance_fn: Optional callable replacing ``cbottle.denoiser_factories.get_guidance``.
+            sampler: Optional callable replacing ``edm_sampler_from_sigma``.
 
         """
         if batch["target"].device != self.device:
@@ -626,8 +643,21 @@ class CBottle3d:
                 if self.channels_last:
                     guidance_data = guidance_data.to(memory_format=torch.channels_last)
 
+            # Call the guidance hook whenever the caller supplied a guidance_fn
+            # (even if guidance_data is None and guidance_scale is 0) OR when we
+            # have classifier guidance data with positive scale (the original
+            # default path). A caller supplying only guidance_fn uses it purely
+            # for per-step inspection/tracking; its contribution to ``d`` is
+            # suppressed by the ``guidance_scale * d_guide`` multiplier.
+            _call_guidance = guidance_fn is not None or (
+                guidance_data is not None and guidance_scale > 0
+            )
+            _classifier_logits_needed = (
+                guidance_data is not None and guidance_scale > 0 and guidance_fn is None
+            )
+
             def D(x_hat, t_hat):
-                if guidance_data is not None:
+                if _call_guidance:
                     x_hat.requires_grad_(True)
 
                 out = self.net(
@@ -651,41 +681,53 @@ class CBottle3d:
                 else:
                     d2 = 0.0
                 d = out.out.where(mask, d2)
-                if guidance_data is not None and guidance_scale > 0:
-                    if self.separate_classifier is not None:
-                        out.logits = self.separate_classifier(
-                            x_hat,
-                            t_hat,
-                            class_labels=labels,
-                            condition=condition,
-                            second_of_day=second_of_day,
-                            day_of_year=day_of_year,
-                        ).logits
-                    elif out.logits is None:
-                        raise ValueError(
-                            "Model did not produce `logits`. Are you sure this model was trained with guidance?"
-                        )
-                    else:
-                        # use the logits from the main model
-                        pass
-                    d_guide = cbottle.denoiser_factories.get_guidance(
-                        guidance_data, out.logits, x_hat, d, t_hat
+                if _call_guidance:
+                    # Logits are only required when we'll be calling the default
+                    # classifier get_guidance (which needs them). Custom
+                    # guidance_fns can handle ``logits=None`` themselves.
+                    if guidance_data is not None and guidance_scale > 0:
+                        if self.separate_classifier is not None:
+                            out.logits = self.separate_classifier(
+                                x_hat,
+                                t_hat,
+                                class_labels=labels,
+                                condition=condition,
+                                second_of_day=second_of_day,
+                                day_of_year=day_of_year,
+                            ).logits
+                        elif out.logits is None and _classifier_logits_needed:
+                            raise ValueError(
+                                "Model did not produce `logits`. Are you sure this model was trained with guidance?"
+                            )
+                        else:
+                            # use the logits from the main model
+                            pass
+                    # If the caller supplied guidance_fn, use it; else fall back to the
+                    # module-level get_guidance (still monkey-patchable for back-compat).
+                    _gfn = (
+                        guidance_fn
+                        if guidance_fn is not None
+                        else cbottle.denoiser_factories.get_guidance
                     )
-                    d = d + guidance_scale * d_guide
+                    d_guide = _gfn(guidance_data, out.logits, x_hat, d, t_hat)
+                    d = d + guidance_scale * d_guide  # zero-safe when guidance_scale=0
                     if self.channels_last:
                         d = d.to(memory_format=torch.channels_last)
 
                 return d
 
-            if guidance_data is not None:
+            if _call_guidance:
                 D = torch.enable_grad(D)
 
             D.round_sigma = self.net.round_sigma
             D.sigma_max = self.net.sigma_max
             D.sigma_min = self.net.sigma_min
 
+            # If the caller supplied a custom sampler, use it; else fall back to the
+            # module-level edm_sampler_from_sigma (still monkey-patchable for back-compat).
+            _sampler = sampler if sampler is not None else edm_sampler_from_sigma
             with torch.autocast("cuda", enabled=bf16, dtype=torch.bfloat16):
-                out = edm_sampler_from_sigma(
+                out = _sampler(
                     D,
                     xT,
                     randn_like=torch.randn_like,
@@ -709,6 +751,219 @@ class CBottle3d:
         return self.classifier_grid.ang2pix(
             torch.as_tensor(lons), torch.as_tensor(lats)
         )
+
+    def calculate_odds_ratio(
+        self,
+        batch: dict,
+        guidance_pixels: torch.Tensor,
+        *,
+        num_steps: int = 36,
+        sigma_min: float = 0.002,
+        sigma_max: float = 200.0,
+        rho: float = 7.0,
+        extra_steps_intervals: "Sequence[tuple[float, float, int]]" = ((15, 20, 25),),
+        guidance_scale: float = 64.0 * 20.0,
+        guidance_on: float = 15.0,
+        guidance_off: float = 20.0,
+        divergence_samples: int = 3,
+        bf16: bool = True,
+        start_from_noisy_image: bool = False,
+        run_backward: bool = True,
+        forward_guidance: bool = True,
+        compute_forward_divergences: bool = True,
+        seed: int | None = None,
+    ) -> dict:
+        """Compute log-odds-ratio ingredients for ``batch`` under classifier guidance.
+
+        Runs a forward pass (``batch["target"]`` -> noise) and, when
+        ``run_backward=True``, two backward passes (noise -> sample, with and
+        without classifier guidance). Each phase records Hutchinson-estimated
+        divergence integrals; the backward samples additionally get a Gaussian
+        reference logp. The log-odds-ratio is recovered as::
+
+            log p_unguided / p_guided
+            ~= (backward_no_guidance_gaussian_logp - backward_gaussian_logp)
+             + (backward_no_guidance_score_div_integral - backward_score_div_integral)
+             - backward_guidance_div_integral
+
+        For an unguided true log-likelihood via the probability-flow ODE use
+        :func:`cbottle.likelihood.log_prob` instead. Defaults match the TC
+        paper configuration (36 steps densified to 61 in the [15,20] sigma
+        window, ``guidance_scale = 64 * 20``).
+
+        Args:
+            batch: Data batch (same format as :meth:`sample`).
+            guidance_pixels: Guidance pixel index tensor; see
+                :meth:`get_guidance_pixels`.
+            run_backward: If ``False``, only run the forward pass.
+            forward_guidance: If ``False``, forward pass runs without the
+                classifier guidance gradient.
+            compute_forward_divergences: If ``False``, skip Hutchinson probes
+                on the forward pass.
+            seed: If set, seeds the initial Gaussian noise for the forward
+                phase so the method is deterministic run-to-run. The two
+                backward phases use the forward latents as their starting
+                point, so they inherit this seed implicitly. Hutchinson probes
+                are always deterministically seeded per step.
+
+        Returns:
+            Dict with scalar divergence integrals (``*_div_integral``), two
+            Gaussian reference logps (``*_gaussian_logp``), ``initial_log_prob``
+            (scalar log p of the forward-step-0 xT under N(0, sigma_max^2)),
+            and tensors for the raw untransformed phase outputs (``*_latents``).
+            Callers running many batches should drop the tensor keys before
+            accumulating.
+        """
+        if batch["target"].device != self.device:
+            batch = self._move_to_device(batch)
+
+        schedule_kwargs = dict(
+            num_steps=num_steps,
+            sigma_min=sigma_min,
+            sigma_max=sigma_max,
+            rho=rho,
+            extra_steps_intervals=extra_steps_intervals,
+        )
+        sigma_schedule_fn = lambda t_hat: default_sigma_schedule(  # noqa: E731
+            t_hat, guidance_on=guidance_on, guidance_off=guidance_off
+        )
+
+        def _run_phase(
+            *,
+            reverse: bool,
+            compute_guidance: bool,
+            start_latents=None,
+            phase: str,
+            compute_divergences: bool = True,
+        ):
+            logging.info(
+                f"calculate_odds_ratio: running phase '{phase}' "
+                f"(reverse={reverse}, guidance={compute_guidance})"
+            )
+            if compute_guidance:
+                strategy = ClassifierGuidanceStrategy()
+                guidance_pixels_eff = guidance_pixels
+                scale = guidance_scale
+                tracker_scale = guidance_scale
+            else:
+                strategy = None
+                guidance_pixels_eff = None
+                scale = 0.0
+                # With no guidance strategy the scale is unused inside the
+                # tracker (it only multiplies a zero vector); pass 0 for
+                # clarity rather than the caller's scale.
+                tracker_scale = 0.0
+
+            tracker = DivergenceTracker(
+                guidance_strategy=strategy,
+                guidance_scale=tracker_scale,
+                sigma_max=sigma_max,
+                divergence_samples=divergence_samples,
+                phase=phase,
+                compute_score_div=compute_divergences,
+                compute_guidance_div=compute_divergences and compute_guidance,
+                sigma_schedule=sigma_schedule_fn,
+            )
+            sampler_func = _make_reverse_aware_sampler(
+                reverse=reverse,
+                start_latents=start_latents,
+                progress_desc=f"calculate_odds_ratio[{phase}]",
+                **schedule_kwargs,
+            )
+
+            _processed, _coords, raw = self._sample_with_latents(
+                batch,
+                seed=seed,
+                start_from_noisy_image=start_from_noisy_image,
+                guidance_pixels=guidance_pixels_eff,
+                guidance_scale=scale,
+                bf16=bf16,
+                return_untransformed=True,
+                guidance_fn=tracker,
+                sampler=sampler_func,
+            )
+            return raw, tracker
+
+        # ---- Forward ---------------------------------------------------------
+        forward_phase = "forward" if forward_guidance else "forward_no_guidance"
+        forward_latents, forward_tracker = _run_phase(
+            reverse=False,
+            compute_guidance=forward_guidance,
+            start_latents=None,
+            phase=forward_phase,
+            compute_divergences=compute_forward_divergences,
+        )
+        forward_guidance_div_integral = calculate_divergence_integral(
+            forward_tracker.data, "divergence", "forward"
+        )
+        forward_score_div_integral = calculate_divergence_integral(
+            forward_tracker.data, "score_divergence", "forward"
+        )
+
+        results: dict = {
+            "forward_guidance_div_integral": float(forward_guidance_div_integral),
+            "forward_score_div_integral": float(forward_score_div_integral),
+            "initial_log_prob": forward_tracker.initial_log_prob,
+            "forward_latents": forward_latents,
+        }
+
+        if not run_backward:
+            return results
+
+        # ---- Backward with guidance -----------------------------------------
+        backward_latents, backward_tracker = _run_phase(
+            reverse=True,
+            compute_guidance=True,
+            start_latents=forward_latents,
+            phase="backward",
+        )
+        backward_guidance_div_integral = calculate_divergence_integral(
+            backward_tracker.data, "divergence", "backward"
+        )
+        backward_score_div_integral = calculate_divergence_integral(
+            backward_tracker.data, "score_divergence", "backward"
+        )
+        backward_gaussian_logp = calculate_gaussian_logp(backward_latents, sigma_max)
+
+        # ---- Backward without guidance --------------------------------------
+        (
+            backward_no_guidance_latents,
+            backward_no_guidance_tracker,
+        ) = _run_phase(
+            reverse=True,
+            compute_guidance=False,
+            start_latents=forward_latents,
+            phase="backward_no_guidance",
+        )
+        backward_no_guidance_guidance_div_integral = calculate_divergence_integral(
+            backward_no_guidance_tracker.data, "divergence", "backward"
+        )
+        backward_no_guidance_score_div_integral = calculate_divergence_integral(
+            backward_no_guidance_tracker.data, "score_divergence", "backward"
+        )
+        backward_no_guidance_gaussian_logp = calculate_gaussian_logp(
+            backward_no_guidance_latents, sigma_max
+        )
+
+        results.update(
+            {
+                "backward_guidance_div_integral": float(backward_guidance_div_integral),
+                "backward_score_div_integral": float(backward_score_div_integral),
+                "backward_gaussian_logp": float(backward_gaussian_logp),
+                "backward_no_guidance_guidance_div_integral": float(
+                    backward_no_guidance_guidance_div_integral
+                ),
+                "backward_no_guidance_score_div_integral": float(
+                    backward_no_guidance_score_div_integral
+                ),
+                "backward_no_guidance_gaussian_logp": float(
+                    backward_no_guidance_gaussian_logp
+                ),
+                "backward_latents": backward_latents,
+                "backward_no_guidance_latents": backward_no_guidance_latents,
+            }
+        )
+        return results
 
     def sample_for_superresolution(
         self,

--- a/src/cbottle/inference/__init__.py
+++ b/src/cbottle/inference/__init__.py
@@ -529,6 +529,7 @@ class CBottle3d:
         guidance_pixels: torch.Tensor | None = None,
         guidance_scale: float = 0.03,
         bf16=True,
+        spatial_mask: torch.Tensor | None = None,
         return_untransformed: bool = False,
     ):
         """
@@ -548,6 +549,7 @@ class CBottle3d:
             guidance_pixels=guidance_pixels,
             guidance_scale=guidance_scale,
             bf16=bf16,
+            spatial_mask=spatial_mask,
             pre_generated_latents=None,
             return_untransformed=return_untransformed,
         )
@@ -560,6 +562,7 @@ class CBottle3d:
         guidance_pixels: torch.Tensor | None = None,
         guidance_scale: float = 0.03,
         bf16=True,
+        spatial_mask: torch.Tensor | None = None,
         pre_generated_latents: torch.Tensor | None = None,
         return_untransformed: bool = False,
         guidance_fn: Callable[
@@ -609,6 +612,9 @@ class CBottle3d:
             label_ind
         ]  # n, c
         mask = mask[:, :, None, None]
+        spatial_mask_gpu = (
+            spatial_mask.to(self.device) if spatial_mask is not None else None
+        )
 
         with torch.no_grad():
             device = condition.device
@@ -680,8 +686,11 @@ class CBottle3d:
                 if _call_guidance:
                     x_hat.requires_grad_(True)
 
+                x_in = x_hat.where(mask, 0)
+                if spatial_mask_gpu is not None:
+                    x_in = x_in * spatial_mask_gpu
                 out = self.net(
-                    x_hat.where(mask, 0),
+                    x_in,
                     t_hat,
                     class_labels=labels,
                     condition=condition,
@@ -701,6 +710,8 @@ class CBottle3d:
                 else:
                     d2 = 0.0
                 d = out.out.where(mask, d2)
+                if spatial_mask_gpu is not None:
+                    d = d * spatial_mask_gpu
                 if _call_guidance:
                     # Logits are only required when we'll be calling the default
                     # classifier get_guidance (which needs them). Custom

--- a/src/cbottle/loss.py
+++ b/src/cbottle/loss.py
@@ -107,6 +107,7 @@ class EDMLoss:
         net: Callable[..., cbottle.models.networks.Output],
         images,
         classifier_labels=None,
+        spatial_mask=None,
     ) -> Output:
         if self.distribution == "log_normal":
             sigma = self._sample_sigma_like_v1(images)
@@ -119,6 +120,9 @@ class EDMLoss:
 
         _, _, _t, _x = range(4)
         mask = ~torch.isnan(images).any(dim=(_t, _x), keepdim=True)
+        if spatial_mask is not None:
+            sm = spatial_mask[0] if spatial_mask.dim() > 1 else spatial_mask
+            mask = mask & (sm != 0)
         weight = (sigma**2 + self.sigma_data**2) / (sigma * self.sigma_data) ** 2
         y = images
         n = torch.randn_like(y) * sigma

--- a/src/cbottle/models/networks.py
+++ b/src/cbottle/models/networks.py
@@ -33,7 +33,7 @@ from earth2grid.healpix import (
     Grid,
     PaddingBackends,
     PixelOrder,
-    # pad_backend,
+    pad_backend,
 )
 from earth2grid.healpix import pad as healpix_pad
 from torch.nn.functional import silu
@@ -511,11 +511,10 @@ class Conv2dHealpix(torch.nn.Module):
         )
         x = x.permute(0, 1, 4, 2, 3)  # channels_last N F C H W
         # TODO: Add torch.compile for indexing backend
-        # commented for preventing graph breaks for demo
-        # if x.is_cuda:
-        #     torch.cuda.set_device(x.device)  # WORK AROUND FOR EARTH2GRID BUG
-        # with pad_backend(self.padding_backend):
-        x = healpix_pad(x, padding)
+        if x.is_cuda:
+            torch.cuda.set_device(x.device)  # WORK AROUND FOR EARTH2GRID BUG
+        with pad_backend(self.padding_backend):
+            x = healpix_pad(x, padding)
         x = x.permute(0, 1, 3, 4, 2)  # N F H W C
         # No transpose reshape
         x = einops.rearrange(x, "(b t) f x y c -> (b t f) x y c", b=B, t=T, f=F, c=C)

--- a/src/cbottle/odds_ratio.py
+++ b/src/cbottle/odds_ratio.py
@@ -24,9 +24,10 @@ use :mod:`cbottle.likelihood`.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import math
-from typing import Callable, Sequence
+from typing import Callable, Iterable, Sequence
 
 import numpy as np
 import torch
@@ -35,14 +36,73 @@ logger = logging.getLogger(__name__)
 
 
 __all__ = [
-    "DivergenceComputer",
     "DivergenceTracker",
-    "classifier_bce_guidance",
+    "OddsRatioResult",
+    "classifier_guidance",
     "calculate_divergence_integral",
     "calculate_gaussian_logp",
     "default_sigma_schedule",
-    "create_custom_time_steps",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class OddsRatioResult:
+    """Return type of :meth:`CBottle3d.calculate_odds_ratio`.
+
+    Forward-phase fields are always populated. Backward-phase fields are
+    ``None`` when ``run_backward=False``. The :attr:`log_odds_ratio` property
+    combines the backward fields into ``log p_unguided / p_guided`` at the
+    target sample.
+    """
+
+    # Forward phase
+    forward_guidance_div_integral: float
+    forward_score_div_integral: float
+    forward_latents: torch.Tensor
+    initial_log_prob: float | None
+
+    # Backward-with-guidance phase
+    backward_guidance_div_integral: float | None = None
+    backward_score_div_integral: float | None = None
+    backward_gaussian_logp: float | None = None
+    backward_latents: torch.Tensor | None = None
+
+    # Backward-without-guidance phase
+    backward_no_guidance_guidance_div_integral: float | None = None
+    backward_no_guidance_score_div_integral: float | None = None
+    backward_no_guidance_gaussian_logp: float | None = None
+    backward_no_guidance_latents: torch.Tensor | None = None
+
+    @property
+    def log_odds_ratio(self) -> float:
+        """``log p_unguided / p_guided`` at the target sample.
+
+        Requires the two backward phases (``run_backward=True``).
+        """
+        if (
+            self.backward_gaussian_logp is None
+            or self.backward_no_guidance_gaussian_logp is None
+            or self.backward_score_div_integral is None
+            or self.backward_no_guidance_score_div_integral is None
+            or self.backward_guidance_div_integral is None
+        ):
+            raise ValueError(
+                "log_odds_ratio requires both backward phases; "
+                "call calculate_odds_ratio with run_backward=True."
+            )
+        return (
+            (self.backward_no_guidance_gaussian_logp - self.backward_gaussian_logp)
+            + (
+                self.backward_no_guidance_score_div_integral
+                - self.backward_score_div_integral
+            )
+            - self.backward_guidance_div_integral
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -50,47 +110,54 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-class DivergenceComputer:
-    """Estimate divergence of a vector field via the Hutchinson trace trick."""
+def _hutchinson_divergence(
+    x_hat: torch.Tensor,
+    vector: torch.Tensor,
+    t_hat: torch.Tensor,
+    num_samples: int = 3,
+) -> float:
+    """Estimate ``div_x (vector)`` via the Hutchinson trace trick.
 
-    @staticmethod
-    def compute_divergence(x_hat, vector, t_hat, num_samples: int = 3) -> float:
-        """Compute ``div_x (vector)`` using ``num_samples`` Rademacher-free probes.
+    Uses ``num_samples`` Gaussian probes with deterministic seeding (a function
+    of ``t_hat``) for reproducibility across calls at the same sigma. Only
+    ``batch_size = 1`` is supported -- larger batches OOM through the
+    second-order autograd path in practice, so the caller (typically
+    :meth:`CBottle3d._calculate_odds_ratio_full`) enforces this upstream.
 
-        Args:
-            x_hat: Input tensor (``requires_grad=True`` is expected).
-            vector: Vector field (same shape as ``x_hat``).
-            t_hat: Current noise level (used purely for deterministic seeding).
-            num_samples: Monte Carlo samples.
-        """
-        if torch.norm(vector) == 0:
-            return 0.0
+    Args:
+        x_hat: Input tensor with ``shape[0] == 1`` and ``requires_grad=True``.
+        vector: Vector field of the same shape as ``x_hat``.
+        t_hat: Current noise level; used only for seeding.
+        num_samples: Monte Carlo probes to average over.
+    """
+    if torch.norm(vector) == 0:
+        return 0.0
 
-        divergence_val = torch.zeros(x_hat.shape[0], device=x_hat.device)
-        dims = list(range(1, x_hat.ndim))
+    divergence_val = torch.zeros(x_hat.shape[0], device=x_hat.device)
+    dims = list(range(1, x_hat.ndim))
 
-        for i in range(num_samples):
-            seed = int(t_hat * 1000) + i
-            generator = torch.Generator(device=x_hat.device).manual_seed(seed)
+    for i in range(num_samples):
+        seed = int(t_hat * 1000) + i
+        generator = torch.Generator(device=x_hat.device).manual_seed(seed)
 
-            e = torch.randn(
-                x_hat.shape,
-                device=x_hat.device,
-                dtype=x_hat.dtype,
-                generator=generator,
-            )
-            gf = torch.sum(vector * e)
-            gf.backward(retain_graph=True)
+        e = torch.randn(
+            x_hat.shape,
+            device=x_hat.device,
+            dtype=x_hat.dtype,
+            generator=generator,
+        )
+        gf = torch.sum(vector * e)
+        gf.backward(retain_graph=True)
 
-            if x_hat.grad is not None:
-                div_sample = torch.sum(x_hat.grad * e, dim=dims)
-                divergence_val += div_sample / num_samples
-                x_hat.grad = None
-                gf = None
-            else:
-                break
+        if x_hat.grad is not None:
+            div_sample = torch.sum(x_hat.grad * e, dim=dims)
+            divergence_val += div_sample / num_samples
+            x_hat.grad = None
+            gf = None
+        else:
+            break
 
-        return float(divergence_val.item())
+    return float(divergence_val.item())
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +165,7 @@ class DivergenceComputer:
 # ---------------------------------------------------------------------------
 
 
-def classifier_bce_guidance(
+def classifier_guidance(
     guidance_data: torch.Tensor, logits: torch.Tensor, x_hat: torch.Tensor
 ) -> torch.Tensor:
     """Raw (unscaled) BCE-classifier guidance gradient ``-dL/dx_hat``.
@@ -167,16 +234,42 @@ class DivergenceTracker:
         self.compute_guidance_div = compute_guidance_div
         self.sigma_schedule = sigma_schedule
 
-        self.divergence_computer = DivergenceComputer()
         self.data: list[dict] = []
         self.initial_log_prob: float | None = None
 
     # -- guidance hook ----------------------------------------------------
-    def __call__(self, guidance_data, logits, x_hat, denoised, t_hat):
+    def __call__(
+        self,
+        guidance_data: torch.Tensor | None,
+        logits: torch.Tensor | None,
+        x_hat: torch.Tensor,
+        denoised: torch.Tensor,
+        t_hat: torch.Tensor,
+    ) -> torch.Tensor:
+        """Record per-step divergence trace and return scaled guidance.
+
+        Shapes (with ``B`` = batch, ``C`` = ``net.img_channels``, ``T`` =
+        ``net.time_length``, ``X`` = number of HPX pixels at the model
+        resolution, ``X_c`` = number of pixels at the classifier resolution):
+
+        - ``guidance_data``: ``(B, 1, 1, X_c)`` (``NaN`` outside guidance
+          mask) or ``None`` in no-guidance mode.
+        - ``logits``: ``(B, 1, 1, X_c)`` from the classifier head, or
+          ``None`` in no-guidance mode.
+        - ``x_hat``: ``(B, C, T, X)``, ``requires_grad=True``.
+        - ``denoised``: ``(B, C, T, X)``.
+        - ``t_hat``: scalar tensor (current sigma).
+
+        Returns ``(B, C, T, X)`` -- the sigma-schedule-scaled guidance vector,
+        detached from the backward graph.
+        """
+        if x_hat.grad is not None:
+            x_hat.grad = None
+
         # Record the initial (step 0) log p(x | N(0, sigma_max^2)) as a scalar
-        # -- only on the forward phase so downstream consumers can combine
-        # with the backward logps.
-        if self.initial_log_prob is None and self.phase == "forward":
+        # on any forward variant ("forward" or "forward_no_guidance") so
+        # downstream consumers can combine with the backward logps.
+        if self.initial_log_prob is None and self.phase.startswith("forward"):
             self.initial_log_prob = calculate_gaussian_logp(
                 x_hat.detach(), self.sigma_max
             )
@@ -213,12 +306,12 @@ class DivergenceTracker:
             # schedule, so dividing by t_hat gives the per-step contribution
             # to the drift whose divergence we want.
             full_guidance = self.guidance_scale / t_hat * scaled_guidance
-            divergence_val = -self.divergence_computer.compute_divergence(
+            divergence_val = -_hutchinson_divergence(
                 x_hat, full_guidance, t_hat, self.divergence_samples
             )
 
         if self.compute_score_div:
-            score_div_val = self.divergence_computer.compute_divergence(
+            score_div_val = _hutchinson_divergence(
                 x_hat, score.clone(), t_hat, self.divergence_samples
             )
 
@@ -291,7 +384,7 @@ def calculate_gaussian_logp(sample: torch.Tensor, sigma: float) -> float:
 # ---------------------------------------------------------------------------
 
 
-def create_custom_time_steps(
+def _create_custom_time_steps(
     net,
     device,
     *,
@@ -341,7 +434,7 @@ def _edm_sampler_with_custom_steps(
     S_max: float = float("inf"),
     S_noise: float = 0,
     randn_like=torch.randn_like,
-    progress_desc: str | None = None,
+    progress_wrapper: Callable[[Iterable], Iterable] | None = None,
     # The following are accepted and ignored to satisfy the calling convention
     # used by ``_sample_with_latents``; the schedule is fully specified by
     # ``t_steps`` so they are redundant here. Explicit rather than **kwargs to
@@ -353,16 +446,16 @@ def _edm_sampler_with_custom_steps(
 ):
     """Deterministic EDM sampler honoring an externally provided sigma schedule.
 
-    If ``progress_desc`` is set, wraps the sigma loop in a tqdm bar labelled
-    with that string (useful for per-phase progress inside long
-    :meth:`CBottle3d.calculate_odds_ratio` runs).
+    If ``progress_wrapper`` is set, the per-step iterable is passed through it
+    once before iteration -- typically a tqdm wrapper for live progress, but
+    callers can substitute any iterable-to-iterable transform.
     """
     x_next = latents.to(torch.float64)
-    steps = list(zip(t_steps[:-1], t_steps[1:]))
-    if progress_desc is not None:
-        from tqdm.auto import tqdm
-
-        steps = tqdm(steps, desc=progress_desc, leave=False)
+    steps: Iterable[tuple[torch.Tensor, torch.Tensor]] = list(
+        zip(t_steps[:-1], t_steps[1:])
+    )
+    if progress_wrapper is not None:
+        steps = progress_wrapper(steps)
 
     for t_cur, t_next in steps:
         x_cur = x_next
@@ -390,7 +483,7 @@ def _make_reverse_aware_sampler(
     sigma_max: float = 200.0,
     rho: float = 7.0,
     extra_steps_intervals: Sequence[tuple[float, float, int]] = (),
-    progress_desc: str | None = None,
+    progress_wrapper: Callable[[Iterable], Iterable] | None = None,
 ):
     """Build a sampler closure compatible with ``_sample_with_latents``.
 
@@ -408,7 +501,7 @@ def _make_reverse_aware_sampler(
     _sigma_max = sigma_max
     _rho = rho
     _extra_steps_intervals = extra_steps_intervals
-    _progress_desc = progress_desc
+    _progress_wrapper = progress_wrapper
 
     def _sampler(
         net,
@@ -422,7 +515,7 @@ def _make_reverse_aware_sampler(
         time_stepper=None,
     ):
         device = latents.device
-        t_steps = create_custom_time_steps(
+        t_steps = _create_custom_time_steps(
             net,
             device,
             num_steps=_num_steps,
@@ -446,7 +539,7 @@ def _make_reverse_aware_sampler(
             latents,
             t_steps,
             randn_like=randn_like,
-            progress_desc=_progress_desc,
+            progress_wrapper=_progress_wrapper,
         )
 
     return _sampler

--- a/src/cbottle/odds_ratio.py
+++ b/src/cbottle/odds_ratio.py
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Classifier-guided log-odds-ratio helpers for :class:`CBottle3d`.
+
+Provides the divergence tracker, classifier guidance strategy, and custom
+EDM schedule used by :meth:`CBottle3d.calculate_odds_ratio`. The module
+computes odds-ratio *ingredients* (per-phase Hutchinson divergence integrals,
+Gaussian reference logps), not a standalone log-likelihood; for the latter
+use :mod:`cbottle.likelihood`.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Callable, Sequence
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "DivergenceComputer",
+    "DivergenceTracker",
+    "ClassifierGuidanceStrategy",
+    "calculate_divergence_integral",
+    "calculate_gaussian_logp",
+    "default_sigma_schedule",
+    "create_custom_time_steps",
+]
+
+
+# ---------------------------------------------------------------------------
+# Divergence computation (Hutchinson trace estimator)
+# ---------------------------------------------------------------------------
+
+
+class DivergenceComputer:
+    """Estimate divergence of a vector field via the Hutchinson trace trick."""
+
+    @staticmethod
+    def compute_divergence(x_hat, vector, t_hat, num_samples: int = 3) -> float:
+        """Compute ``div_x (vector)`` using ``num_samples`` Rademacher-free probes.
+
+        Args:
+            x_hat: Input tensor (``requires_grad=True`` is expected).
+            vector: Vector field (same shape as ``x_hat``).
+            t_hat: Current noise level (used purely for deterministic seeding).
+            num_samples: Monte Carlo samples.
+        """
+        if torch.norm(vector) == 0:
+            return 0.0
+
+        divergence_val = torch.zeros(x_hat.shape[0], device=x_hat.device)
+        dims = list(range(1, x_hat.ndim))
+
+        for i in range(num_samples):
+            seed = int(t_hat * 1000) + i
+            generator = torch.Generator(device=x_hat.device).manual_seed(seed)
+
+            e = torch.randn(
+                x_hat.shape,
+                device=x_hat.device,
+                dtype=x_hat.dtype,
+                generator=generator,
+            )
+            gf = torch.sum(vector * e)
+            gf.backward(retain_graph=True)
+
+            if x_hat.grad is not None:
+                div_sample = torch.sum(x_hat.grad * e, dim=dims)
+                divergence_val += div_sample / num_samples
+                x_hat.grad = None
+                gf = None
+            else:
+                break
+
+        return float(divergence_val.item())
+
+
+# ---------------------------------------------------------------------------
+# Classifier-based guidance strategy
+# ---------------------------------------------------------------------------
+
+
+class ClassifierGuidanceStrategy:
+    """Binary-cross-entropy classifier guidance.
+
+    Returns the *raw* (unscaled) gradient; the caller is expected to apply
+    the sigma schedule and ``guidance_scale`` scaling.
+    """
+
+    def compute_guidance(self, guidance_data, logits, x_hat, denoised, t_hat):
+        guidance_mask = ~torch.isnan(guidance_data)
+        valid_logits = logits[guidance_mask]
+        valid_targets = guidance_data[guidance_mask]
+
+        if valid_logits.numel() == 0:
+            return torch.zeros_like(x_hat), {"classifier_norm": 0.0}
+
+        x_hat.requires_grad_(True)
+        x_hat.grad = None
+
+        loss = torch.nn.functional.binary_cross_entropy_with_logits(
+            valid_logits, valid_targets, reduction="sum"
+        )
+        classifier_grad = torch.autograd.grad(loss, x_hat, create_graph=True)[0]
+
+        # Negative gradient because we minimise the classifier loss.
+        guidance = -classifier_grad
+        metadata = {"classifier_norm": float(torch.norm(classifier_grad).item())}
+        return guidance, metadata
+
+
+# ---------------------------------------------------------------------------
+# Divergence tracker (used as ``guidance_fn`` hook)
+# ---------------------------------------------------------------------------
+
+
+def default_sigma_schedule(
+    t_hat, guidance_on: float = 0.0, guidance_off: float = float("inf")
+):
+    """Default classifier-guidance sigma schedule: linear-in-sigma in [on, off]."""
+    return t_hat if guidance_on < t_hat < guidance_off else 0.0
+
+
+class DivergenceTracker:
+    """Callable ``guidance_fn`` that records per-step divergence traces.
+
+    Installed via ``_sample_with_latents(..., guidance_fn=tracker)``. Pass
+    ``guidance_strategy=None`` for no-guidance mode: the hook still fires so
+    score divergence is tracked, but the returned guidance contribution is zero.
+    The ``"forward"`` phase also records ``initial_log_prob`` at step 0.
+    """
+
+    def __init__(
+        self,
+        guidance_strategy: "ClassifierGuidanceStrategy | None" = None,
+        *,
+        guidance_scale: float = 1.0,
+        sigma_max: float = 200.0,
+        divergence_samples: int = 1,
+        phase: str = "forward",
+        compute_score_div: bool = True,
+        compute_guidance_div: bool = True,
+        sigma_schedule: Callable[[torch.Tensor], float] = default_sigma_schedule,
+    ):
+        self.guidance_strategy = guidance_strategy
+        self.guidance_scale = guidance_scale
+        self.sigma_max = sigma_max
+        self.divergence_samples = divergence_samples
+        self.phase = phase
+        self.compute_score_div = compute_score_div
+        self.compute_guidance_div = compute_guidance_div
+        self.sigma_schedule = sigma_schedule
+
+        self.divergence_computer = DivergenceComputer()
+        self.data: list[dict] = []
+        self.initial_log_prob: float | None = None
+
+    # -- guidance hook ----------------------------------------------------
+    def __call__(self, guidance_data, logits, x_hat, denoised, t_hat):
+        # Record the initial (step 0) log p(x | N(0, sigma_max^2)) as a scalar
+        # -- only on the forward phase so downstream consumers can combine
+        # with the backward logps.
+        if self.initial_log_prob is None and self.phase == "forward":
+            self.initial_log_prob = calculate_gaussian_logp(
+                x_hat.detach(), self.sigma_max
+            )
+
+        sigma_weight = self.sigma_schedule(t_hat)
+
+        # Compute RAW guidance. If strategy is None run in no-guidance mode:
+        # zeros are contributed and guidance divergence is skipped (score
+        # divergence is still tracked below).
+        if self.guidance_strategy is not None:
+            raw_guidance, _ = self.guidance_strategy.compute_guidance(
+                guidance_data, logits, x_hat, denoised, t_hat
+            )
+            scaled_guidance = sigma_weight * raw_guidance
+            scaled_norm = float(torch.norm(raw_guidance).item() * sigma_weight)
+        else:
+            scaled_guidance = torch.zeros_like(x_hat)
+            scaled_norm = 0.0
+
+        # Score
+        score = (x_hat - denoised) / t_hat
+        score_norm_val = float(torch.norm(score).item())
+
+        # Divergences
+        divergence_val = 0.0
+        score_div_val = 0.0
+
+        if (
+            self.compute_guidance_div
+            and self.guidance_strategy is not None
+            and torch.norm(scaled_guidance) > 0
+            and sigma_weight != 0
+        ):
+            # _sample_with_latents adds ``guidance_scale * d_guide`` to ``d``.
+            # ``scaled_guidance`` is already pre-multiplied by the sigma
+            # schedule, so dividing by t_hat gives the per-step contribution
+            # to the drift whose divergence we want.
+            full_guidance = self.guidance_scale / t_hat * scaled_guidance
+            divergence_val = -self.divergence_computer.compute_divergence(
+                x_hat, full_guidance, t_hat, self.divergence_samples
+            )
+
+        if self.compute_score_div:
+            score_div_val = self.divergence_computer.compute_divergence(
+                x_hat, score.clone(), t_hat, self.divergence_samples
+            )
+
+        sigma_val = float(t_hat) if hasattr(t_hat, "item") else float(t_hat)
+        self.data.append(
+            {
+                "sigma": sigma_val,
+                "score_norm": score_norm_val,
+                "classifier_norm": scaled_norm,
+                "divergence": float(divergence_val),
+                "score_divergence": float(score_div_val),
+                "phase": self.phase,
+            }
+        )
+
+        # Detach before returning: the divergence has already been evaluated,
+        # so the autograd graph on ``scaled_guidance`` is no longer needed.
+        scaled_guidance_detached = scaled_guidance.detach()
+        if x_hat.grad is not None:
+            x_hat.grad = None
+        return scaled_guidance_detached
+
+
+# ---------------------------------------------------------------------------
+# Likelihood reductions
+# ---------------------------------------------------------------------------
+
+
+def calculate_divergence_integral(
+    divergence_data: Sequence[dict],
+    divergence_key: str = "divergence",
+    phase: str = "forward",
+) -> float:
+    """Trapezoidal integration of a per-step divergence trace over sigma.
+
+    For forward sampling the integration goes high -> low sigma, so the sign
+    is flipped; for backward we integrate low -> high and keep the sign.
+    """
+    if not divergence_data:
+        return 0.0
+
+    sigma = [data["sigma"] for data in divergence_data]
+    divergence = [data[divergence_key] for data in divergence_data]
+    divergence = [0.0 if np.isnan(d) else d for d in divergence]
+
+    try:
+        if phase == "backward":
+            return np.trapz(divergence, sigma)
+        return -np.trapz(divergence, sigma)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(f"Error integrating {divergence_key}: {e}")
+        return 0.0
+
+
+def calculate_gaussian_logp(sample: torch.Tensor, sigma: float) -> float:
+    """Log probability of ``sample`` under ``N(0, sigma^2 I)``.
+
+    Torch-native (no scipy dependency).
+    """
+    d = sample.numel()
+    log_2pi = math.log(2.0 * math.pi)
+    log_sigma_sq = 2.0 * math.log(sigma)
+    norm_sq = torch.sum(sample**2).item()
+    logp = -0.5 * (d * log_2pi + d * log_sigma_sq + norm_sq / (sigma**2))
+    return float(logp)
+
+
+# ---------------------------------------------------------------------------
+# Custom EDM sampler / schedule (used by CBottle3d.calculate_odds_ratio)
+# ---------------------------------------------------------------------------
+
+
+def create_custom_time_steps(
+    net,
+    device,
+    *,
+    num_steps: int = 18,
+    sigma_min: float = 0.002,
+    sigma_max: float = 200.0,
+    rho: float = 7.0,
+    extra_steps_intervals: Sequence[tuple[float, float, int]] = (),
+) -> torch.Tensor:
+    """Build the EDM sigma schedule used by the likelihood sampler.
+
+    Mirrors the schedule used by the original discrete likelihood sampler:
+    standard EDM polynomial discretisation, optionally densified inside one
+    or more ``(start_sigma, end_sigma, num_extra)`` intervals.
+    """
+    step_indices = torch.arange(num_steps, dtype=torch.float64, device=device)
+    t_steps = (
+        sigma_max ** (1 / rho)
+        + step_indices
+        / (num_steps - 1)
+        * (sigma_min ** (1 / rho) - sigma_max ** (1 / rho))
+    ) ** rho
+    t_steps = net.round_sigma(t_steps)
+
+    if extra_steps_intervals:
+        extra_steps: list[float] = []
+        for start_sigma, end_sigma, num_extra in extra_steps_intervals:
+            extra_indices = torch.linspace(0, 1, num_extra, device=device)
+            extra_sigmas = start_sigma + extra_indices * (end_sigma - start_sigma)
+            extra_sigmas = net.round_sigma(extra_sigmas)
+            extra_steps.extend(extra_sigmas.tolist())
+
+        all_steps = torch.cat(
+            [t_steps, torch.tensor(extra_steps, dtype=torch.float64, device=device)]
+        )
+        t_steps = torch.sort(all_steps, descending=True)[0]
+
+    return t_steps
+
+
+def _edm_sampler_with_custom_steps(
+    net,
+    latents,
+    t_steps,
+    S_churn: float = 0,
+    S_min: float = 0,
+    S_max: float = float("inf"),
+    S_noise: float = 0,
+    randn_like=torch.randn_like,
+    progress_desc: str | None = None,
+    # The following are accepted and ignored to satisfy the calling convention
+    # used by ``_sample_with_latents``; the schedule is fully specified by
+    # ``t_steps`` so they are redundant here. Explicit rather than **kwargs to
+    # prevent silent typo-swallowing.
+    sigma_min=None,
+    sigma_max=None,
+    num_steps=None,
+    time_stepper=None,
+):
+    """Deterministic EDM sampler honoring an externally provided sigma schedule.
+
+    If ``progress_desc`` is set, wraps the sigma loop in a tqdm bar labelled
+    with that string (useful for per-phase progress inside long
+    :meth:`CBottle3d.calculate_odds_ratio` runs).
+    """
+    x_next = latents.to(torch.float64)
+    steps = list(zip(t_steps[:-1], t_steps[1:]))
+    if progress_desc is not None:
+        from tqdm.auto import tqdm
+
+        steps = tqdm(steps, desc=progress_desc, leave=False)
+
+    for t_cur, t_next in steps:
+        x_cur = x_next
+        gamma = (
+            min(S_churn / len(t_steps), np.sqrt(2) - 1)
+            if S_min <= t_cur <= S_max
+            else 0
+        )
+        t_hat = net.round_sigma(t_cur + gamma * t_cur)
+        x_hat = x_cur + (t_hat**2 - t_cur**2).sqrt() * S_noise * randn_like(x_cur)
+
+        denoised = net(x_hat, t_hat).to(torch.float64)
+        d_cur = (x_hat - denoised) / t_hat
+        x_next = x_hat + (t_next - t_hat) * d_cur
+
+    return x_next
+
+
+def _make_reverse_aware_sampler(
+    reverse: bool,
+    start_latents: torch.Tensor | None = None,
+    *,
+    num_steps: int = 18,
+    sigma_min: float = 0.002,
+    sigma_max: float = 200.0,
+    rho: float = 7.0,
+    extra_steps_intervals: Sequence[tuple[float, float, int]] = (),
+    progress_desc: str | None = None,
+):
+    """Build a sampler closure compatible with ``_sample_with_latents``.
+
+    For ``reverse=False`` the schedule runs high -> low sigma and the raw
+    integration endpoint ``sigma=0`` is appended; for ``reverse=True`` the
+    schedule is flipped (low -> high sigma) with the tail restored to the
+    *raw* ``sigma_max`` (before round_sigma) so the downstream
+    ``log p(x | N(0, sigma_max^2))`` uses exactly the caller's sigma_max.
+    """
+    # Alias the outer schedule params so the inner closure can name its own
+    # (shadowed) kwargs with the same names as in the ``_sample_with_latents``
+    # calling convention without accidentally referring to them.
+    _num_steps = num_steps
+    _sigma_min = sigma_min
+    _sigma_max = sigma_max
+    _rho = rho
+    _extra_steps_intervals = extra_steps_intervals
+    _progress_desc = progress_desc
+
+    def _sampler(
+        net,
+        latents,
+        *,
+        randn_like=torch.randn_like,
+        # Accepted and ignored (see _edm_sampler_with_custom_steps above).
+        sigma_min=None,
+        sigma_max=None,
+        num_steps=None,
+        time_stepper=None,
+    ):
+        device = latents.device
+        t_steps = create_custom_time_steps(
+            net,
+            device,
+            num_steps=_num_steps,
+            sigma_min=_sigma_min,
+            sigma_max=_sigma_max,
+            rho=_rho,
+            extra_steps_intervals=_extra_steps_intervals,
+        )
+
+        if reverse and start_latents is not None:
+            latents = start_latents.clone()
+
+        if not reverse:
+            t_steps = torch.cat([t_steps, torch.zeros_like(t_steps[:1])])
+        else:
+            t_steps = torch.flip(t_steps, [0]).clone()
+            t_steps[-1] = _sigma_max
+
+        return _edm_sampler_with_custom_steps(
+            net,
+            latents,
+            t_steps,
+            randn_like=randn_like,
+            progress_desc=_progress_desc,
+        )
+
+    return _sampler

--- a/src/cbottle/odds_ratio.py
+++ b/src/cbottle/odds_ratio.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "DivergenceComputer",
     "DivergenceTracker",
-    "ClassifierGuidanceStrategy",
+    "classifier_bce_guidance",
     "calculate_divergence_integral",
     "calculate_gaussian_logp",
     "default_sigma_schedule",
@@ -94,37 +94,35 @@ class DivergenceComputer:
 
 
 # ---------------------------------------------------------------------------
-# Classifier-based guidance strategy
+# Classifier-based guidance gradient
 # ---------------------------------------------------------------------------
 
 
-class ClassifierGuidanceStrategy:
-    """Binary-cross-entropy classifier guidance.
+def classifier_bce_guidance(
+    guidance_data: torch.Tensor, logits: torch.Tensor, x_hat: torch.Tensor
+) -> torch.Tensor:
+    """Raw (unscaled) BCE-classifier guidance gradient ``-dL/dx_hat``.
 
-    Returns the *raw* (unscaled) gradient; the caller is expected to apply
-    the sigma schedule and ``guidance_scale`` scaling.
+    The caller (typically :class:`DivergenceTracker`) applies the sigma
+    schedule and ``guidance_scale``. Returns a zero tensor if the guidance
+    mask is empty.
     """
+    guidance_mask = ~torch.isnan(guidance_data)
+    valid_logits = logits[guidance_mask]
+    valid_targets = guidance_data[guidance_mask]
 
-    def compute_guidance(self, guidance_data, logits, x_hat, denoised, t_hat):
-        guidance_mask = ~torch.isnan(guidance_data)
-        valid_logits = logits[guidance_mask]
-        valid_targets = guidance_data[guidance_mask]
+    if valid_logits.numel() == 0:
+        return torch.zeros_like(x_hat)
 
-        if valid_logits.numel() == 0:
-            return torch.zeros_like(x_hat), {"classifier_norm": 0.0}
+    x_hat.requires_grad_(True)
+    x_hat.grad = None
 
-        x_hat.requires_grad_(True)
-        x_hat.grad = None
-
-        loss = torch.nn.functional.binary_cross_entropy_with_logits(
-            valid_logits, valid_targets, reduction="sum"
-        )
-        classifier_grad = torch.autograd.grad(loss, x_hat, create_graph=True)[0]
-
-        # Negative gradient because we minimise the classifier loss.
-        guidance = -classifier_grad
-        metadata = {"classifier_norm": float(torch.norm(classifier_grad).item())}
-        return guidance, metadata
+    loss = torch.nn.functional.binary_cross_entropy_with_logits(
+        valid_logits, valid_targets, reduction="sum"
+    )
+    classifier_grad = torch.autograd.grad(loss, x_hat, create_graph=True)[0]
+    # Negative gradient because we minimise the classifier loss.
+    return -classifier_grad
 
 
 # ---------------------------------------------------------------------------
@@ -143,14 +141,14 @@ class DivergenceTracker:
     """Callable ``guidance_fn`` that records per-step divergence traces.
 
     Installed via ``_sample_with_latents(..., guidance_fn=tracker)``. Pass
-    ``guidance_strategy=None`` for no-guidance mode: the hook still fires so
-    score divergence is tracked, but the returned guidance contribution is zero.
+    ``guidance_fn=None`` for no-guidance mode: the hook still fires so score
+    divergence is tracked, but the returned guidance contribution is zero.
     The ``"forward"`` phase also records ``initial_log_prob`` at step 0.
     """
 
     def __init__(
         self,
-        guidance_strategy: "ClassifierGuidanceStrategy | None" = None,
+        guidance_fn: Callable | None = None,
         *,
         guidance_scale: float = 1.0,
         sigma_max: float = 200.0,
@@ -160,7 +158,7 @@ class DivergenceTracker:
         compute_guidance_div: bool = True,
         sigma_schedule: Callable[[torch.Tensor], float] = default_sigma_schedule,
     ):
-        self.guidance_strategy = guidance_strategy
+        self.guidance_fn = guidance_fn
         self.guidance_scale = guidance_scale
         self.sigma_max = sigma_max
         self.divergence_samples = divergence_samples
@@ -185,13 +183,11 @@ class DivergenceTracker:
 
         sigma_weight = self.sigma_schedule(t_hat)
 
-        # Compute RAW guidance. If strategy is None run in no-guidance mode:
-        # zeros are contributed and guidance divergence is skipped (score
-        # divergence is still tracked below).
-        if self.guidance_strategy is not None:
-            raw_guidance, _ = self.guidance_strategy.compute_guidance(
-                guidance_data, logits, x_hat, denoised, t_hat
-            )
+        # Compute RAW guidance. If guidance_fn is None run in no-guidance
+        # mode: zeros are contributed and guidance divergence is skipped
+        # (score divergence is still tracked below).
+        if self.guidance_fn is not None:
+            raw_guidance = self.guidance_fn(guidance_data, logits, x_hat)
             scaled_guidance = sigma_weight * raw_guidance
             scaled_norm = float(torch.norm(raw_guidance).item() * sigma_weight)
         else:
@@ -208,7 +204,7 @@ class DivergenceTracker:
 
         if (
             self.compute_guidance_div
-            and self.guidance_strategy is not None
+            and self.guidance_fn is not None
             and torch.norm(scaled_guidance) > 0
             and sigma_weight != 0
         ):

--- a/src/cbottle/storage.py
+++ b/src/cbottle/storage.py
@@ -21,7 +21,9 @@ import sys
 
 import fsspec
 
-DEFAULT_PATH = os.path.expanduser("~/.config/rclone/rclone.conf")
+DEFAULT_PATH = os.getenv(
+    "RCLONE_CONFIG", os.path.expanduser("~/.config/rclone/rclone.conf")
+)
 
 
 class StorageConfigError(Exception):

--- a/tests/unit/test_dataset_tas_only.py
+++ b/tests/unit/test_dataset_tas_only.py
@@ -20,6 +20,7 @@ import torch
 
 from cbottle.datasets import dataset_3d
 
+
 def test_get_loaders_tas_only_with_sst(monkeypatch):
     calls = {"tas": None, "sst_offset": None}
 
@@ -37,7 +38,9 @@ def test_get_loaders_tas_only_with_sst(monkeypatch):
 
     monkeypatch.setattr(dataset_3d, "NetCDFTasLoader", DummyNetCDFTasLoader)
     monkeypatch.setattr(dataset_3d, "AmipSSTLoader", DummyAmipSSTLoader)
-    monkeypatch.setattr(dataset_3d.earth2grid.healpix, "Grid", lambda *args, **kwargs: DummyGrid())
+    monkeypatch.setattr(
+        dataset_3d.earth2grid.healpix, "Grid", lambda *args, **kwargs: DummyGrid()
+    )
 
     loaders = dataset_3d._get_loaders(
         "tas_only",

--- a/tests/unit/test_dataset_tas_only.py
+++ b/tests/unit/test_dataset_tas_only.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import datetime
+
+import cftime
+import numpy as np
+import torch
+
+from cbottle.datasets import dataset_3d
+
+def test_get_loaders_tas_only_with_sst(monkeypatch):
+    calls = {"tas": None, "sst_offset": None}
+
+    class DummyNetCDFTasLoader:
+        def __init__(self, directory: str, variable_name: str = "tas"):
+            calls["tas"] = (directory, variable_name)
+
+    class DummyAmipSSTLoader:
+        def __init__(self, grid, sst_offset: float = 0.0):
+            calls["sst_offset"] = sst_offset
+            self.grid = grid
+
+    class DummyGrid:
+        pass
+
+    monkeypatch.setattr(dataset_3d, "NetCDFTasLoader", DummyNetCDFTasLoader)
+    monkeypatch.setattr(dataset_3d, "AmipSSTLoader", DummyAmipSSTLoader)
+    monkeypatch.setattr(dataset_3d.earth2grid.healpix, "Grid", lambda *args, **kwargs: DummyGrid())
+
+    loaders = dataset_3d._get_loaders(
+        "tas_only",
+        sst_input=True,
+        sst_offset=1.5,
+        variable_config=dataset_3d.VARIABLE_CONFIGS["tas_only"],
+    )
+
+    assert len(loaders) == 2
+    assert isinstance(loaders[0], DummyNetCDFTasLoader)
+    assert isinstance(loaders[1], DummyAmipSSTLoader)
+    assert calls["tas"] == (dataset_3d.config.TAS_ONLY_NETCDF_DIR, "tas")
+    assert calls["sst_offset"] == 1.5
+
+
+def test_encode_netcdf_tas_applies_zero_spatial_mask():
+    npix = 12 * 4**dataset_3d.HPX_LEVEL
+    variable_config = dataset_3d.VARIABLE_CONFIGS["tas_only"]
+    data = {
+        ("tas", dataset_3d.NO_LEVEL): np.ones(npix, dtype=np.float32),
+        ("tosbcs", dataset_3d.NO_LEVEL): np.ones(npix, dtype=np.float32) * 300.0,
+    }
+    time = cftime.DatetimeGregorian(2001, 1, 1, 0, 0, 0)
+    spatial_mask = torch.zeros(npix, dtype=torch.float32)
+
+    out = dataset_3d._encode_netcdf_tas(
+        time=time,
+        data=data,
+        label=dataset_3d.LABELS.index("era5"),
+        mean=dataset_3d.get_mean(variable_config),
+        scale=dataset_3d.get_std(variable_config),
+        variable_config=variable_config,
+        spatial_mask=spatial_mask,
+    )
+
+    assert out["target"].shape == (1, 1, npix)
+    assert torch.all(out["target"] == 0)
+    assert torch.equal(out["spatial_mask"], spatial_mask)
+    day_start = time.replace(hour=0, minute=0, second=0)
+    year_start = day_start.replace(month=1, day=1)
+    expected_second_of_day = (time - day_start) / datetime.timedelta(seconds=1)
+    expected_day_of_year = (time - year_start) / datetime.timedelta(seconds=86400)
+    assert out["second_of_day"].item() == expected_second_of_day
+    assert out["day_of_year"].item() == expected_day_of_year

--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -191,6 +191,10 @@ class MockClassifier:
     def __init__(self):
         self.is_called = False
 
+    def to(self, device):
+        # No parameters to move; satisfies CBottle3d._move_models_to_device.
+        return self
+
     def __call__(self, x_hat, *args, **kwargs):
         self.is_called = True
         # Use x_hat in the computation so gradients can flow through

--- a/tests/unit/test_odds_ratio.py
+++ b/tests/unit/test_odds_ratio.py
@@ -37,11 +37,13 @@ class MockClassifier:
     def __init__(self):
         self.is_called = False
 
+    def to(self, device):
+        # No parameters to move; satisfies CBottle3d._move_models_to_device.
+        return self
+
     def __call__(self, x_hat, *args, **kwargs):
         self.is_called = True
-        logits = (
-            torch.ones(1, 1, 1, 12 * 8**2, requires_grad=True).cuda() * x_hat.mean()
-        )
+        logits = torch.ones(1, 1, 1, 12 * 8**2).cuda() * x_hat.mean()
         return Output(out=None, logits=logits)
 
 
@@ -81,17 +83,18 @@ def _make_batch():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_calculate_odds_ratio_forward_only():
+def test_calculate_odds_ratio_full_forward_only():
+    """run_backward=False populates the forward fields and leaves backward as None."""
     classifier = MockClassifier()
     model = _make_tiny_cbottle3d(classifier)
     batch = _make_batch()
     guidance_pixels = torch.tensor([0]).cuda()
 
-    results = model.calculate_odds_ratio(
+    result = model._calculate_odds_ratio_full(
         batch,
         guidance_pixels,
         num_steps=2,
-        extra_steps_intervals=(),  # no densification at this tiny size
+        extra_steps_intervals=(),
         divergence_samples=1,
         guidance_on=0.0,
         guidance_off=float("inf"),
@@ -99,21 +102,11 @@ def test_calculate_odds_ratio_forward_only():
         bf16=False,
     )
 
-    # Forward-only contract: scalar + tensor keys, no backward fields.
-    assert set(results.keys()) == {
-        "forward_guidance_div_integral",
-        "forward_score_div_integral",
-        "initial_log_prob",
-        "forward_latents",
-    }
-    for k in (
-        "forward_guidance_div_integral",
-        "forward_score_div_integral",
-        "initial_log_prob",
-    ):
-        assert isinstance(results[k], float)
-        assert math.isfinite(results[k])
-    assert results["forward_latents"].shape == batch["target"].shape
+    assert math.isfinite(result.forward_score_div_integral)
+    assert result.forward_latents.shape == batch["target"].shape
+    assert result.backward_gaussian_logp is None
+    with pytest.raises(ValueError):
+        _ = result.log_odds_ratio
     assert classifier.is_called
 
 
@@ -124,7 +117,7 @@ def test_calculate_odds_ratio_full_three_phases():
     batch = _make_batch()
     guidance_pixels = torch.tensor([0]).cuda()
 
-    results = model.calculate_odds_ratio(
+    result = model._calculate_odds_ratio_full(
         batch,
         guidance_pixels,
         num_steps=2,
@@ -136,29 +129,36 @@ def test_calculate_odds_ratio_full_three_phases():
         bf16=False,
     )
 
-    expected_scalar_keys = {
-        "forward_guidance_div_integral",
-        "forward_score_div_integral",
-        "backward_guidance_div_integral",
-        "backward_score_div_integral",
-        "backward_no_guidance_guidance_div_integral",
-        "backward_no_guidance_score_div_integral",
-        "backward_gaussian_logp",
-        "backward_no_guidance_gaussian_logp",
-        "initial_log_prob",
-    }
-    expected_tensor_keys = {
-        "forward_latents",
-        "backward_latents",
-        "backward_no_guidance_latents",
-    }
-    assert set(results.keys()) == expected_scalar_keys | expected_tensor_keys
+    assert math.isfinite(result.forward_score_div_integral)
+    assert math.isfinite(result.log_odds_ratio)
+    assert isinstance(result.backward_latents, torch.Tensor)
 
-    for k in expected_scalar_keys:
-        assert isinstance(results[k], float), k
-        assert math.isfinite(results[k]), k
-    for k in expected_tensor_keys:
-        assert isinstance(results[k], torch.Tensor), k
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_calculate_odds_ratio_simple_wrapper():
+    """The user-visible ``calculate_odds_ratio`` returns ``(float, Tensor)``."""
+    classifier = MockClassifier()
+    model = _make_tiny_cbottle3d(classifier)
+    batch = _make_batch()
+    guidance_pixels = torch.tensor([0]).cuda()
+
+    log_odds_ratio, forward_latents = model.calculate_odds_ratio(
+        batch,
+        guidance_pixels,
+        num_steps=2,
+        extra_steps_intervals=(),
+        divergence_samples=1,
+        guidance_on=0.0,
+        guidance_off=float("inf"),
+        bf16=False,
+    )
+    assert isinstance(log_odds_ratio, float) and math.isfinite(log_odds_ratio)
+    assert forward_latents.shape == batch["target"].shape
+
+    with pytest.raises(ValueError):
+        model.calculate_odds_ratio(
+            batch, guidance_pixels, num_steps=2, run_backward=False
+        )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/tests/unit/test_odds_ratio.py
+++ b/tests/unit/test_odds_ratio.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Locks the contract of the guidance-hook path in ``_sample_with_latents``
+and catches accidental regressions in the upstreamed log-odds-ratio
+pipeline. Uses the same tiny CBottle3d + MockClassifier harness as
+``test_inference.test_cbottle3d_sample``.
+"""
+
+import math
+
+import pytest
+import torch
+
+from cbottle import models
+from cbottle.datasets.base import BatchInfo
+from cbottle.datasets.dataset_2d import MAX_CLASSES as LABEL_DIM
+from cbottle.inference import CBottle3d
+from cbottle.models.networks import Output
+
+
+class MockClassifier:
+    """Mirror of test_inference.MockClassifier with gradient-flowing logits."""
+
+    def __init__(self):
+        self.is_called = False
+
+    def __call__(self, x_hat, *args, **kwargs):
+        self.is_called = True
+        logits = (
+            torch.ones(1, 1, 1, 12 * 8**2, requires_grad=True).cuda() * x_hat.mean()
+        )
+        return Output(out=None, logits=logits)
+
+
+def _make_tiny_cbottle3d(separate_classifier):
+    net = models.get_model(
+        models.ModelConfigV1(model_channels=8, out_channels=3, label_dim=LABEL_DIM)
+    )
+    net.batch_info = BatchInfo(
+        channels=["rlut", "rsut", "rsds"],
+        scales=[1.0, 1.0, 1.0],
+        center=[0.0, 0.0, 0.0],
+    )
+    net.cuda()
+    # channels_last=False keeps the NCHW path so autograd through the
+    # healpix pad survives (same path the likelihood regression uses).
+    return CBottle3d(
+        net,
+        sigma_min=0.02,
+        sigma_max=200.0,
+        num_steps=2,
+        channels_last=False,
+        separate_classifier=separate_classifier,
+    )
+
+
+def _make_batch():
+    shape = (1, 3, 1, 12 * 64 * 64)
+    return {
+        "target": torch.randn(*shape).cuda(),
+        "labels": torch.nn.functional.one_hot(
+            torch.tensor([1]), num_classes=LABEL_DIM
+        ).cuda(),
+        "condition": torch.zeros(1, 0, 1, shape[-1]).cuda(),
+        "second_of_day": torch.tensor([[43200]]).cuda(),
+        "day_of_year": torch.tensor([[180]]).cuda(),
+    }
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_calculate_odds_ratio_forward_only():
+    classifier = MockClassifier()
+    model = _make_tiny_cbottle3d(classifier)
+    batch = _make_batch()
+    guidance_pixels = torch.tensor([0]).cuda()
+
+    results = model.calculate_odds_ratio(
+        batch,
+        guidance_pixels,
+        num_steps=2,
+        extra_steps_intervals=(),  # no densification at this tiny size
+        divergence_samples=1,
+        guidance_on=0.0,
+        guidance_off=float("inf"),
+        run_backward=False,
+        bf16=False,
+    )
+
+    # Forward-only contract: scalar + tensor keys, no backward fields.
+    assert set(results.keys()) == {
+        "forward_guidance_div_integral",
+        "forward_score_div_integral",
+        "initial_log_prob",
+        "forward_latents",
+    }
+    for k in (
+        "forward_guidance_div_integral",
+        "forward_score_div_integral",
+        "initial_log_prob",
+    ):
+        assert isinstance(results[k], float)
+        assert math.isfinite(results[k])
+    assert results["forward_latents"].shape == batch["target"].shape
+    assert classifier.is_called
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_calculate_odds_ratio_full_three_phases():
+    classifier = MockClassifier()
+    model = _make_tiny_cbottle3d(classifier)
+    batch = _make_batch()
+    guidance_pixels = torch.tensor([0]).cuda()
+
+    results = model.calculate_odds_ratio(
+        batch,
+        guidance_pixels,
+        num_steps=2,
+        extra_steps_intervals=(),
+        divergence_samples=1,
+        guidance_on=0.0,
+        guidance_off=float("inf"),
+        run_backward=True,
+        bf16=False,
+    )
+
+    expected_scalar_keys = {
+        "forward_guidance_div_integral",
+        "forward_score_div_integral",
+        "backward_guidance_div_integral",
+        "backward_score_div_integral",
+        "backward_no_guidance_guidance_div_integral",
+        "backward_no_guidance_score_div_integral",
+        "backward_gaussian_logp",
+        "backward_no_guidance_gaussian_logp",
+        "initial_log_prob",
+    }
+    expected_tensor_keys = {
+        "forward_latents",
+        "backward_latents",
+        "backward_no_guidance_latents",
+    }
+    assert set(results.keys()) == expected_scalar_keys | expected_tensor_keys
+
+    for k in expected_scalar_keys:
+        assert isinstance(results[k], float), k
+        assert math.isfinite(results[k]), k
+    for k in expected_tensor_keys:
+        assert isinstance(results[k], torch.Tensor), k
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_sample_with_latents_hooks_guidance_fn_without_data():
+    """guidance_fn is honored even when guidance_data is None (backward-no-guidance path).
+
+    Locks the _call_guidance gating added alongside calculate_odds_ratio:
+    passing a guidance_fn must enable the hook even with guidance_scale=0,
+    so the tracker can still observe each step.
+    """
+    classifier = MockClassifier()
+    model = _make_tiny_cbottle3d(classifier)
+    batch = _make_batch()
+
+    calls: list[float] = []
+
+    def tracker_fn(guidance_data, logits, x_hat, denoised, t_hat):
+        calls.append(float(t_hat))
+        return torch.zeros_like(x_hat)
+
+    _processed, _coords, _raw = model._sample_with_latents(
+        batch,
+        guidance_pixels=None,
+        guidance_scale=0.0,
+        bf16=False,
+        return_untransformed=True,
+        guidance_fn=tracker_fn,
+    )
+
+    assert calls, "tracker_fn should have been invoked at each step"


### PR DESCRIPTION
- Scope: one commit (bfe1098) focused on adding tas_only dataset support plus spatial_mask plumbing through training/inference.
- Dataset/config changes: dataset_3d gets tas_only handling and mask-aware encoding; environment/storage add env-driven config knobs (including TAS_ONLY_NETCDF_DIR, RCLONE_CONFIG).
- Training/inference path: train_coarse, loss, diagnostics, and inference are updated so mask-aware conditioning/loss/sampling can run end-to-end.
- Tests: adds tests/unit/test_dataset_tas_only.py with loader wiring checks (with/without SST) and mask-application behavior.