### PR TITLE
Creating optional dependency groups

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ test:
     - make lint
     # TODO: training and inference tests should be split into different envs
     - python3 -m pip install earth2studio==0.13.0 pytest-regtest
-    - pip install --group training --group visualization -e .
+    - pip install -e .[training,visualization]
     - make pytest
     - pytest tests/integration -k 'not train_uncond'
     # TODO fix the scripts tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,8 +94,9 @@ test:
     - python -m pip install mypy==1.9.0
     - PIP_CONSTRAINT="" make install-linters
     - make lint
-    - python3 -m pip install earth2studio==0.8.1 pytest-regtest
-    - pip install -e .
+    # TODO: training and inference tests should be split into different envs
+    - python3 -m pip install earth2studio==0.13.0 pytest-regtest
+    - pip install --group training --group visualization -e .
     - make pytest
     - pytest tests/integration -k 'not train_uncond'
     # TODO fix the scripts tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,27 +11,33 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "cartopy>=0.24.1",
     "cftime>=1.6.4.post1",
     "earth2grid>=2025.6.1",
     "h5netcdf>=1.6.1",
-    "matplotlib>=3",
     "netCDF4>=1.7.0",
     "numpy>=1.25.0",
     "pandas>=2.2.3",
     "psutil>=6.0.0",
     "nvidia-physicsnemo>=2.0.0",
-    "python-dotenv>=1.1.0",
     "s3fs>=2025.3.2",
     "scipy>=1",
-    "tensorboard>=2.16.0",
     "torch>=2.5.0",
-    "torchmetrics>=1.0.0",
-    "tqdm>=4.67.1",
     "xarray>=2025.3.1",
     "zarr>=3.0.7",
     "zict>=3.0.0",
+]
+
+[project.optional-dependencies]
+training = [
+    "python-dotenv>=1.1.0",
+    "tensorboard>=2.16.0",
+    "torchmetrics>=1.0.0",
+    "tqdm>=4.67.1",
     "fastgen @ git+https://github.com/NVlabs/FastGen.git",
+]
+visualization = [
+     "cartopy>=0.24.1",
+    "matplotlib>=3",
 ]
 
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "s3fs>=2025.3.2",
     "scipy>=1",
     "torch>=2.5.0",
+    "tqdm>=4.67.1",
     "xarray>=2025.3.1",
     "zarr>=3.0.7",
     "zict>=3.0.0",
@@ -32,7 +33,6 @@ training = [
     "python-dotenv>=1.1.0",
     "tensorboard>=2.16.0",
     "torchmetrics>=1.0.0",
-    "tqdm>=4.67.1",
     "fastgen @ git+https://github.com/NVlabs/FastGen.git",
 ]
 visualization = [

--- a/src/cbottle/odds_ratio.py
+++ b/src/cbottle/odds_ratio.py
@@ -359,8 +359,8 @@ def calculate_divergence_integral(
 
     try:
         if phase == "backward":
-            return np.trapz(divergence, sigma)
-        return -np.trapz(divergence, sigma)
+            return np.trapezoid(divergence, sigma)
+        return -np.trapezoid(divergence, sigma)
     except Exception as e:  # pragma: no cover - defensive
         logger.warning(f"Error integrating {divergence_key}: {e}")
         return 0.0


### PR DESCRIPTION
Flash attention has some annoying pinned dependencies, additionally there are some additional dependencies in the current  list that aren't needed for inference usage. This sections out the known training only dependencies and also visualization dependencies that are not needed.

With the current main it is not possible to use cBottle in Earth2Studio.